### PR TITLE
Expand Mobile putfile RPC

### DIFF
--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -1,4 +1,4 @@
-```
+
 # Expand Mobile putfile RPC
 
 * Proposal: [SDL-NNNN](NNNN-filename.md)
@@ -24,6 +24,7 @@ Proposed solution is introducing an optional 4-byte CRC checksum in putfile RPC.
 ## Detailed design
 
 Addition to MOBILE API:
+```
 <enum name="Result" internal_scope="base">
     <element name="Corrupted_DATA">
       <description>The data sent failed to pass CRC check in receiver end</description>
@@ -48,11 +49,11 @@ Addition to MOBILE API:
     </param>
 
   </function> 
-  
+```
+
   
 ## Impact on existing code
 
 
 ## Alternatives considered
 
-````

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -55,8 +55,8 @@ Core should not delete file when one chunk was corrupted and it will response "C
 App will know it is corrupted chunk of data, and it will start retransmission for that chunk.
 
 Major change:
-	1. New parameters to putfile request and response 
-    2. Send "Corrupted_DATA" instead of "Invalid_DATA" to app.(SDL core only change)
+		1. New parameters to putfile request and response 
+		2. Send "Corrupted_DATA" instead of "Invalid_DATA" to app.(SDL core only change)
   
 ## Impact on existing code
 

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -1,0 +1,58 @@
+```
+# Expand Mobile putfile RPC
+
+* Proposal: [SDL-NNNN](NNNN-filename.md)
+* Author: [Martin(Lingxiu) Chen]( https://github.com/lchen139)
+* Status: **Awaiting review**
+* Impacted Platforms: RPC, Core, iOS, Android
+
+## Introduction
+
+This proposal is to expand putfile RPC to incorporate with unreliable wireless medium.
+
+## Motivation
+
+Currently SDL design lies in assumption that transfer medium is 100% reliable and all data will be retrieved correctly in receiver end. However, not every wireless medium is guaranteed to be 100% error free. This error might be introduced by hardware design failure, hardware driver issue and environmental noise interference. Theoretically, transport layer will have retransmission mechanism to handle all this kinds of errors. But wireless mediums like bluetooth can’t have this protection due to comp ability issue with major phone manufacturers (Samsung, HTC, Huawei, .etc).  
+
+The primary motivation of this proposal is to allow developer use CRC checksum to guarantee data integrity in error sensitive scenario (Transfer large binary file).
+
+
+## Proposed solution
+
+Proposed solution is introducing an optional 4-byte CRC checksum in putfile RPC. 32 bit CRC(CRC32) can check data integrity up to 512 Mbit. If SDL core failed to pass CRC check, SDL core will request retry for same putfile operation.
+
+## Detailed design
+
+Addition to MOBILE API:
+<enum name="Result" internal_scope="base">
+    <element name="Corrupted_DATA">
+      <description>The data sent failed to pass CRC check in receiver end</description>
+    </element>
+</enum>
+
+
+  <function name="PutFile" functionID="PutFileID" messagetype="request">
+
+    <param name="CRC Checksum" type="Unsigned Long" minvalue="0" maxvalue="4,294,967,295" mandatory="false">
+      <description>Additional CRC checksum to protect data integrity</description>
+    </param>
+
+  </function>
+  
+ 
+  <function name="PutFile" functionID="PutFileID" messagetype="response">
+
+    <param name="resultCode" type="Result" platform="documentation">
+      <description>See Result</description>
+      <element name="Corrupted_DATA"/>
+    </param>
+
+  </function> 
+  
+  
+## Impact on existing code
+
+
+## Alternatives considered
+
+````

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -50,16 +50,20 @@ Addition to MOBILE API:
 
   </function> 
 ```
+Background for current framework:
+When dealing with large binary file, app breaks file into chunks and putfile chunks one by one to core. If core received the chunk successfully, it will response result code "success" and append that chunk to binary file cache. Otherwise, core will response result code "Invalid_DATA" and that chunk will not be appended to binary file cache. 
 
-Core should not delete file when one chunk was corrupted and it will response "Corrupted_DATA" to app, Instead of "Invalid_DATA". So that the app has a chance to correct that chunk instead of resending entire file.
-App will know it is corrupted chunk of data, and it will start retransmission for that chunk.
+Change:
+Once CRC checksum is enabled, Core will compare CRC checksum calculated by received data and CRC checksum provided by putfile request. If two checksum value doesn't agree to each other, Core will know received data is corrupted. Then, Core shall not delete binary file cache and it should response "Corrupted_DATA" to app, instead of "Invalid_DATA". This gives app a chance to directly correct that  chunk before transfering next chunk. With "Corrupted_DATA" response, app will know it is corrupted chunk of data, it will start retransmitting for that chunk. App will retry up to 5 times(defined by application) before it stop and record errors.
 
 Major change:
 		1. New parameters to putfile request and response 
 		2. Send "Corrupted_DATA" instead of "Invalid_DATA" to app.(SDL core only change)
+		3. SDL core generate CRC32 checksum based on received putfile data if CRC checksum option is enabled. ( SDL core only change)
   
 ## Impact on existing code
 
 
 ## Alternatives considered
 
+NO

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -19,7 +19,7 @@ The primary motivation of this proposal is to allow developer use CRC checksum t
 
 ## Proposed solution
 
-Proposed solution is introducing an optional 4-byte CRC checksum in putfile RPC. 32 bit CRC(CRC32) can check data integrity up to 512 Mbit. If SDL core failed to pass CRC check, SDL core will request retry for same putfile operation.
+Proposed solution is introducing an optional 4-byte CRC checksum in putfile RPC. 32 bit CRC(CRC32) can check data integrity up to 512 Mbit. If SDL core failed to pass CRC check, SDL core will request retry for same putfile operation by feeding back "Corrupted_DATA" result code.
 
 ## Detailed design
 
@@ -35,7 +35,7 @@ Addition to MOBILE API:
   <function name="PutFile" functionID="PutFileID" messagetype="request">
 
     <param name="CRC Checksum" type="Unsigned Long" minvalue="0" maxvalue="4,294,967,295" mandatory="false">
-      <description>Additional CRC32 checksum to protect data integrity</description>
+      <description>Additional CRC32 checksum to protect data integrity up to 512 Mbits</description>
     </param>
 
   </function>
@@ -51,6 +51,12 @@ Addition to MOBILE API:
   </function> 
 ```
 
+Core should not delete file when one chunk was corrupted and it will response "Corrupted_DATA" to app, Instead of "Invalid_DATA". So that the app has a chance to correct that chunk instead of resending entire file.
+App will know it is corrupted chunk of data, and it will start retransmission for that chunk.
+
+Major change:
+	1. New parameters to putfile request and response 
+    2. Send "Corrupted_DATA" instead of "Invalid_DATA" to app.(SDL core only change)
   
 ## Impact on existing code
 

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -73,12 +73,12 @@ Mobile libraries should have a file manager included to support CRC calculation 
 Similar to the TCP design, the CRC checksum is placed at frame header ([SmartDeviceLink Protocol level](https://github.com/smartdevicelink/protocol_spec#22-version-2-frame-header)). The CRC checksum calculation is based on both the frame header and frame payload.
 
 ### Pros:
-- Covers both headers and payloads for all RPC requests
+- Covers both headers and payloads for all SDL communication
 - Research paper ["When The CRC and TCP Checksum Disagree"](conferences.sigcomm.org/sigcomm/2000/conf/paper/sigcomm2000-9-1.pdf) suggests variety error sources in internet will increase error rate from one packets out of few millions to one packets out of few thousand in TCP/IP level.  This approach provides additional robustness for overall system. 
 
 
 ### Cons:
-- Great impact for all RPC request. Major revision for RPC is required.
+- Great impact for SDL protocol. Major revision for SDL protocol is required.
 - If everything is properly designed and implemented. Additional CRC32 might not be useful.
 
 

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -35,7 +35,7 @@ Addition to MOBILE API:
   <function name="PutFile" functionID="PutFileID" messagetype="request">
 
     <param name="CRC Checksum" type="Unsigned Long" minvalue="0" maxvalue="4,294,967,295" mandatory="false">
-      <description>Additional CRC checksum to protect data integrity</description>
+      <description>Additional CRC32 checksum to protect data integrity</description>
     </param>
 
   </function>

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -79,7 +79,7 @@ Similar to the TCP design, the CRC checksum is placed at frame header ([SmartDev
 
 ### Cons:
 - Great impact for SDL protocol. Major revision for SDL protocol is required.
-- If everything is properly designed and implemented. Additional CRC32 might not be useful.
+
 
 
 ##Q&A about Downside

--- a/nnnn-Expand-Mobile-putfile-RPC.md
+++ b/nnnn-Expand-Mobile-putfile-RPC.md
@@ -1,4 +1,5 @@
 
+
 # Expand Mobile putfile RPC
 
 * Proposal: [SDL-NNNN](NNNN-filename.md)
@@ -9,33 +10,38 @@
 ## Introduction
 
 This proposal is to expand putfile RPC to incorporate with unreliable wireless medium.
+This proposal seeks to enhance the reliability of large data transfers to the Head Unit by introducing a field for CRC in the putFile RPC. 
 
 ## Motivation
 
-Currently SDL design lies in assumption that transfer medium is 100% reliable and all data will be retrieved correctly in receiver end. However, not every wireless medium is guaranteed to be 100% error free. This error might be introduced by hardware design failure, hardware driver issue and environmental noise interference. Theoretically, transport layer will have retransmission mechanism to handle all this kinds of errors. But wireless mediums like bluetooth can’t have this protection due to comp ability issue with major phone manufacturers (Samsung, HTC, Huawei, .etc).  
+Current SDL design assumes that the transport medium is 100% reliable and all data will be correctly retrieved by the receiver. 
+However, not every wireless medium is guaranteed to be 100% error free. This error might be introduced by hardware design failure, hardware driver issue and environmental noise interference. Theoretically, transport layer will have retransmission mechanism to handle all this kinds of errors. But wireless mediums like bluetooth can’t have this protection due to compability issue with major phone manufacturers (Samsung, HTC, Huawei, .etc).  
 
 The primary motivation of this proposal is to allow developer use CRC checksum to guarantee data integrity in error sensitive scenario (Transfer large binary file).
 
 
+
 ## Proposed solution
 
-Proposed solution is introducing an optional 4-byte CRC checksum in putfile RPC. 32 bit CRC(CRC32) can check data integrity up to 512 Mbit. If SDL core failed to pass CRC check, SDL core will request retry for same putfile operation by feeding back "Corrupted_DATA" result code.
+Proposed solution introduces an optional 4-byte CRC checksum in putfile RPC. 32 bit CRC(CRC32) can check data integrity up to 512 Mbit. If the CRC check fails, SDL core will request retry for the same putfile operation by sending back  “CORRUPTED_DATA” result code. CRC calculation and retransmission should be handled by file manager inside mobile library. This file manager should be modified to accept a CRC flag passed by application logic.
 
 ## Detailed design
 
 Addition to MOBILE API:
 ```
 <enum name="Result" internal_scope="base">
-    <element name="Corrupted_DATA">
-      <description>The data sent failed to pass CRC check in receiver end</description>
+    <element name="CORRUPTED_DATA">
+      <description>The data sent continuously failed to pass CRC check in receiver end</description>
     </element>
 </enum>
 
 
   <function name="PutFile" functionID="PutFileID" messagetype="request">
 
-    <param name="CRC Checksum" type="Unsigned Long" minvalue="0" maxvalue="4,294,967,295" mandatory="false">
-      <description>Additional CRC32 checksum to protect data integrity up to 512 Mbits</description>
+    
+<param name="CRC" type="Long" minvalue="0" maxvalue="4,294,967,295" mandatory="false">
+<param name="CRC" type="Boolean" mandatory="false">
+      <description> This parameter enables Aadditional CRC32 checksum to protect data integrity up to 512 Mbits . If this parameter is not specified, the value of this parameter should be treated as false </description>
     </param>
 
   </function>
@@ -45,25 +51,28 @@ Addition to MOBILE API:
 
     <param name="resultCode" type="Result" platform="documentation">
       <description>See Result</description>
-      <element name="Corrupted_DATA"/>
+      <element name=" CORRUPTED_DATA "/>
     </param>
 
   </function> 
 ```
 Background for current framework:
-When dealing with large binary file, app breaks file into chunks and putfile chunks one by one to core. If core received the chunk successfully, it will response result code "success" and append that chunk to binary file cache. Otherwise, core will response result code "Invalid_DATA" and that chunk will not be appended to binary file cache. 
+When a large binary file needs to be transferred, the app breaks the file into smaller chunks and sends these chunks to the Head Unit via putFile. If the SDL core on the Head Unit receives the chunk successfully, it will respond with a result code of SUCCESS and append that chunk to the binary cache file. Otherwise, SDL core will responds with a result code of “INVALID_DATA" and that chunk will not be appended to the binary file cache. 
 
 Change:
-Once CRC checksum is enabled, Core will compare CRC checksum calculated by received data and CRC checksum provided by putfile request. If two checksum value doesn't agree to each other, Core will know received data is corrupted. Then, Core shall not delete binary file cache and it should response "Corrupted_DATA" to app, instead of "Invalid_DATA". This gives app a chance to directly correct that  chunk before transfering next chunk. With "Corrupted_DATA" response, app will know it is corrupted chunk of data, it will start retransmitting for that chunk. App will retry up to 5 times(defined by application) before it stop and record errors.
+Mobile library should have a file manager included to support CRC calculation and data retransmission. This file manager should be modified to allow CRC flag passed by application logic. If CRC flag is enabled, file manager will calculate CRC checksum automatically and send putfile request with CRC checksum. Once SDL core receives putfile request with CRC checksum, SDL core will have to calculate the CRC checksum and compare it with the CRC checksum provided in the putFile request. If the two checksums do not match then SDL core will know that the received data has been corrupted and will provide a response of “CORRUPTED_DATA” to the application file manager. When the application file manager receives “CORRUPTED_DATA” response, it should resend the same packet of data. File manager should give up retransmission and log an error after certain number of retries (e.g. 5).Once CRC checksum is enabled, Mobile Library generates CRC32 checksum for data chunk provided by App. Then, mobile library sends this data chunk along with CRC32 checksum to SDL core.  In receiver end, SDL core will have to calculate the CRC checksum and compare it with the CRC checksum provided by mobile library. If the two checksums do not match then SDL core will know that the received data has been corrupted and will request mobile library to resend data along with checksum. SDL core will have a number limit for same data packet retransmission. If retry limit is reached, SDL core will provide a response of “CORRUPTED_DATA” to the application. The app may have a logic resending same chunk of data or logging an error and giving up.
 
-Major change:
-		1. New parameters to putfile request and response 
-		2. Send "Corrupted_DATA" instead of "Invalid_DATA" to app.(SDL core only change)
-		3. SDL core generate CRC32 checksum based on received putfile data if CRC checksum option is enabled. ( SDL core only change)
-  
+
 ## Impact on existing code
+		1. New parameters to putfile request and response (RPC change) 
+		2. Send "CORRUPTED_DATA" instead of "INVALID_DATA" to app.(SDL core only change)
+		3. File Manager inside mMobile Library generates CRC32 checksum and handles file retransmission based on putfile payload data (IOS, Android change). 
+		4. SDL core generates CRC32 checksum based on received putfile data if CRC checksum option is enabled. (SDL core only change)
+		5. Mobile Library and SDL core should have retransmission mechanism for CRC check failure case. (SDL core, IOS and Android change)
+  
 
 
 ## Alternatives considered
 
 NO
+


### PR DESCRIPTION
This proposal expands putfile RPC to incorporate with unreliable wireless medium(like Bluetooth). Introduced CRC32 will add additional data integrity protection for error sensitive scenario ( transfer large binary file). 