### PR TITLE
Retrieving the value of 'menuIcon' and 'menuTitle' parameters from .ini file

### DIFF
--- a/proposals/0026'menuIcon'-menuTitle'-params.md
+++ b/proposals/0026'menuIcon'-menuTitle'-params.md
@@ -1,0 +1,44 @@
+# Retrieving the value of 'menuIcon' and 'menuTitle' parameters from .ini file
+
+* Proposal: [SDL-0026]
+* Author: FORD
+* Status: Awaiting review
+* Impacted Platforms: Core
+[SDL-0026]: https://github.com/smartdevicelink/sdl_evolution/new/master/proposals/0026'menuIcon'-menuTitle'-params.md
+
+## Introduction
+SDL must support absolute and relative path defined in 'menuIcon' parameter.
+
+## Motivation
+SDL must retrieve these default values form .ini file in any applicable cases.  
+Default values of "menuName" and "menuIcon" parameters must be added to .ini file with default values:  
+menuTitle = MENU  
+menuIcon = `<path_to_default_icon>`
+
+In case 'menuIcon' param is empty'MENU' button will be displayed without any icon.
+Path can be relative and absolute.
+
+## Proposed solution
+
+The "menuIcon" parameter defines the path to default menu icon for SetGlobalProperties.  
+In case "menuIcon" is empty -> MENU button will be displayed without any icon 
+By default the value of "menuIcon" must be empty.  
+In case mobile app sends ResetGlobalProperties with "MENUICON" in "Properties" array
+SDL must:  
+retrieve the value of 'menuIcon' parameters from .ini file  
+transfer UI.SetGlobalProperties (` <menuIcon_from_ini_file>` , params) to HMI. 
+
+The "MenuTitle" parameter defines the default value of "menuName" parameter of SetGlobalProperties and must have "MENU" value.  
+In case mobile app sends ResetGlobalProperties with "MENUNAME" in "Properties" array  
+SDL must:  
+retrieve the value of 'menuTitle' parameters from .ini file  
+transfer UI.SetGlobalProperties (` <menuTitle_from_ini_file>` , params) to HMI. 
+
+## Detailed design
+TBD
+
+## Impact on existing code
+TBD
+
+## Alternatives considered
+TBD

--- a/proposals/0026'menuIcon'-menuTitle'-params.md
+++ b/proposals/0026'menuIcon'-menuTitle'-params.md
@@ -1,7 +1,7 @@
 # Retrieving the value of 'menuIcon' and 'menuTitle' parameters from .ini file
 
 * Proposal: [SDL-0026]
-* Author: FORD
+* Author: [Melnyk Tetiana](https://github.com/TMelnyk)
 * Status: Awaiting review
 * Impacted Platforms: Core
 [SDL-0026]: https://github.com/smartdevicelink/sdl_evolution/new/master/proposals/0026'menuIcon'-menuTitle'-params.md
@@ -10,6 +10,7 @@
 SDL must support absolute and relative path defined in 'menuIcon' parameter.
 
 ## Motivation
+**Required for FORD** 
 SDL must retrieve these default values form .ini file in any applicable cases.  
 Default values of "menuName" and "menuIcon" parameters must be added to .ini file with default values:  
 menuTitle = MENU  

--- a/proposals/NNNN-'menuIcon'-menuTitle'-params.md
+++ b/proposals/NNNN-'menuIcon'-menuTitle'-params.md
@@ -1,10 +1,10 @@
 # Retrieving the value of 'menuIcon' and 'menuTitle' parameters from .ini file
 
-* Proposal: [SDL-0026]
+* Proposal: [SDL-NNNN]
 * Author: [Melnyk Tetiana](https://github.com/TMelnyk)
 * Status: Awaiting review
 * Impacted Platforms: Core
-[SDL-0026]: https://github.com/smartdevicelink/sdl_evolution/new/master/proposals/0026'menuIcon'-menuTitle'-params.md
+[SDL-NNNN]: https://github.com/smartdevicelink/sdl_evolution/new/master/proposals/NNNN-'menuIcon'-menuTitle'-params.md
 
 ## Introduction
 SDL must support absolute and relative path defined in 'menuIcon' parameter.

--- a/proposals/NNNN-'menuIcon'-menuTitle'-params.md
+++ b/proposals/NNNN-'menuIcon'-menuTitle'-params.md
@@ -8,9 +8,8 @@
 
 ## Introduction  
 SDL must retrieve the default values of "menuName" and "menuIcon" parameters from to .ini file in case app didn't provide the last ones.  
-## Motivation
-**Required for FORD**  
 
+## Motivation
 SDL must retrieve these default values from .ini file in any applicable cases.  
 Default values of "menuName" and "menuIcon" parameters must be added to .ini file with default values:  
 menuTitle = MENU  
@@ -20,7 +19,6 @@ In case 'menuIcon' param is empty'MENU' button will be displayed without any ico
 Path can be relative and absolute.
 
 ## Proposed solution
-
 1. The "menuIcon" parameter defines the path to default menu icon for SetGlobalProperties.  
 In case "menuIcon" is empty -> MENU button will be displayed without any icon 
 By default the value of "menuIcon" must be empty.  

--- a/proposals/NNNN-'menuIcon'-menuTitle'-params.md
+++ b/proposals/NNNN-'menuIcon'-menuTitle'-params.md
@@ -10,8 +10,9 @@
 SDL must support absolute and relative path defined in 'menuIcon' parameter.
 
 ## Motivation
-**Required for FORD** 
-SDL must retrieve these default values form .ini file in any applicable cases.  
+**Required for FORD**  
+**Required additional clarification from FORD.**  
+SDL must retrieve these default values form .ini file in any applicable cases.  
 Default values of "menuName" and "menuIcon" parameters must be added to .ini file with default values:  
 menuTitle = MENU  
 menuIcon = `<path_to_default_icon>`
@@ -21,7 +22,7 @@ Path can be relative and absolute.
 
 ## Proposed solution
 
-The "menuIcon" parameter defines the path to default menu icon for SetGlobalProperties.  
+1. The "menuIcon" parameter defines the path to default menu icon for SetGlobalProperties.  
 In case "menuIcon" is empty -> MENU button will be displayed without any icon 
 By default the value of "menuIcon" must be empty.  
 In case mobile app sends ResetGlobalProperties with "MENUICON" in "Properties" array
@@ -29,7 +30,7 @@ SDL must:
 retrieve the value of 'menuIcon' parameters from .ini file  
 transfer UI.SetGlobalProperties (` <menuIcon_from_ini_file>` , params) to HMI. 
 
-The "MenuTitle" parameter defines the default value of "menuName" parameter of SetGlobalProperties and must have "MENU" value.  
+2. The "MenuTitle" parameter defines the default value of "menuName" parameter of SetGlobalProperties and must have "MENU" value.  
 In case mobile app sends ResetGlobalProperties with "MENUNAME" in "Properties" array  
 SDL must:  
 retrieve the value of 'menuTitle' parameters from .ini file  

--- a/proposals/NNNN-'menuIcon'-menuTitle'-params.md
+++ b/proposals/NNNN-'menuIcon'-menuTitle'-params.md
@@ -6,13 +6,12 @@
 * Impacted Platforms: Core
 [SDL-NNNN]: https://github.com/smartdevicelink/sdl_evolution/new/master/proposals/NNNN-'menuIcon'-menuTitle'-params.md
 
-## Introduction
-SDL must support absolute and relative path defined in 'menuIcon' parameter.
-
+## Introduction  
+SDL must retrieve the default values of "menuName" and "menuIcon" parameters from to .ini file in case app didn't provide the last ones.  
 ## Motivation
 **Required for FORD**  
-**Required additional clarification from FORD.**  
-SDL must retrieve these default values form .ini file in any applicable cases.  
+
+SDL must retrieve these default values from .ini file in any applicable cases.  
 Default values of "menuName" and "menuIcon" parameters must be added to .ini file with default values:  
 menuTitle = MENU  
 menuIcon = `<path_to_default_icon>`


### PR DESCRIPTION
SDL must retrieve the default values of "menuName" and "menuIcon" parameters from to .ini file in case app didn't provide the last ones. 