### PR TITLE
iOS Logging Redesign

### DIFF
--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -176,10 +176,10 @@ SDLLogE(@"Test error");
 ```
 
 ### Logs
-An `SDLLog` object will contain all of the information necessary to format and log a string. This will be a private class. It will contain something like the following properties:
+An `SDLLogModel` object will contain all of the information necessary to format and log a string. This will be a private class. It will contain something like the following properties:
 
 ```objc
-@interface SDLLog : NSObject <NSCopying>
+@interface SDLLogModel : NSObject <NSCopying>
 
 @property (copy, nonatomic, readonly) NSString *message;
 @property (copy, nonatomic, readonly) NSDate *timestamp;
@@ -209,7 +209,7 @@ We would provide three logging targets (below) that may be enabled by the develo
 
 + (id<SDLLogTarget>)logger;
 - (BOOL)setupLogger;
-- (void)logWithLog:(SDLLog *)log formattedLog:(NSString *)stringLog;
+- (void)logWithLog:(SDLLogModel *)log formattedLog:(NSString *)stringLog;
 - (void)teardownLogger;
 
 @end
@@ -256,7 +256,7 @@ File logging is currently done with a single file that is overwritten when a new
 An `SDLLogFilterBlock` takes a log in and returns whether or not the log passes, a `YES` result will log the message:
 
 ```objc
-typedef BOOL (^SDLLogFilterBlock)(SDLLog *log);
+typedef BOOL (^SDLLogFilterBlock)(SDLLogModel *log);
 ```
 
 ### Modules

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -43,21 +43,21 @@ The public interface will look something like this:
 @property (assign, nonatomic, readonly) BOOL errorAsync;
 
 // Any modules that do not have an explicitly specified level will by default use the global log level;
-@property (assign, nonatomic) SLLogLevel globalLogLevel;
+@property (assign, nonatomic) SDLLogLevel globalLogLevel;
 
 /**
  *  Shared Controller methods are class methods that automatically target the sharedController instance. Since 99% of the time you will want to use the sharedController, these are considered convenience methods.
  */
 #pragma mark - Shared Controller methods
 
-+ (SLLoggerController *)sharedController;
++ (SDLLogManager *)sharedController;
 
 + (void)startWithConfiguration:(SDLLogConfiguration *)configuration;
 
 + (void)addFilters:(NSArray<SDLLogFilterBlock> *)filters;
 + (void)removeFilters:(NSArray<SDLLogFilterBlock> *)filters;
 
-+ (void)logWithLevel:(SLLogLevel)level
++ (void)logWithLevel:(SDLLogLevel)level
             fileName:(NSString *)fileName
         functionName:(NSString *)functionName
                 line:(NSInteger)line
@@ -91,7 +91,7 @@ typedef NS_ENUM(NSUInteger, SDLLogFormatType) {
 @property (assign, nonatomic, readonly) SDLLogOutput *logOutput;
 
 // Initial log filters, these will be able to be changed on `SDLLogManager` at runtime. Defaults to none.
-@property (copy, nonatomic, readonly) NSSet<SLLogFilterBlock> *logFilters;
+@property (copy, nonatomic, readonly) NSSet<SDLLogFilterBlock> *logFilters;
 
 // How detailed of logs will be output. Defaults to Default.
 @property (assign, nonatomic, readonly) SDLLogFormatType formatType;
@@ -199,8 +199,8 @@ The various levels of logging would correspond with various logging levels (abov
 + (SDLLogFilterBlock)filterByAllowingString:(NSString *)string caseInsensitive:(BOOL)caseInsensitive;
 + (SDLLogFilterBlock)filterByDisallowingRegex:(NSRegularExpression *)regex;
 + (SDLLogFilterBlock)filterByAllowingRegex:(NSRegularExpression *)regex;
-+ (SDLLogFilterBlock)filterByAllowingModules:(NSSet<SLFileModule *> *)modules;
-+ (SDLLogFilterBlock)filterByDisallowingModules:(NSSet<SLFileModule *> *)modules;
++ (SDLLogFilterBlock)filterByAllowingModules:(NSSet<SDLLogFileModule *> *)modules;
++ (SDLLogFilterBlock)filterByDisallowingModules:(NSSet<SDLLogFileModule *> *)modules;
 + (SDLLogFilterBlock)filterByAllowingFileNames:(NSSet<NSString *> *)fileNames;
 + (SDLLogFilterBlock)filterByDisallowingFileNames:(NSSet<NSString *> *)fileNames;
 + (SDLLogFilterBlock)filterByAllowingQueues:(NSSet<NSString *> *)queueNames;
@@ -217,10 +217,10 @@ The various levels of logging would correspond with various logging levels (abov
 
 @property (copy, nonatomic, readonly) NSString *name;
 @property (copy, nonatomic, readonly) NSSet<NSString *> *files;
-@property (assign, nonatomic) SLLogLevel logLevel;
+@property (assign, nonatomic) SDLLogLevel logLevel;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files level:(SLLogLevel)level NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files level:(SDLLogLevel)level NS_DESIGNATED_INITIALIZER;
 - (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files;
 - (BOOL)containsFile:(NSString *)fileName;
 

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -22,6 +22,8 @@ The proposed solution is to provide a few additional features:
 
 This proposal is a major version change because it would remove two classes, `SDLDebugTool` is the currently logging class, however, it is unlikely to be used directly by the developer. Second, this change would remove `SDLConsoleController`, which has remained stagnant for many years and nobody the author is aware of uses.
 
+Finally, this proposal would also encompass using this new framework to enhance logging throughout the library using the new log levels and modules, adding log messages throughout the SDL library.
+
 ## Detailed solution
 Much of this is adapted from a logging library I wrote, [SuperLogger](https://github.com/livio/SuperLogger), which has been open-sourced by Livio.
 

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -18,19 +18,19 @@ The proposed solution is to provide a few additional features:
 * Provide multiple levels of logging, such as `Verbose` (see below, "Detailed solution" for a full list).
 * Better log formatting with simple and detailed logs, providing features such as which queue, file, method, and module the log was sent on.
 * Async by default logging, with error logs being synchronous by default.
-* Filters allow only logs that pass a check to actually be logged.
+* Filters allow only logs that pass a check to be logged.
 
-This proposal is a major version change because it would remove two classes, `SDLDebugTool` is the currently logging class, however, it is unlikely to be used directly by the developer. Second, this change would remove `SDLConsoleController`, which has remained stagnant for many years. An extensible logging solution would allow others to create something similar to this if desired.
+This proposal is a major version change because it would remove two classes: `SDLDebugTool` is the currently logging class, however, removing this class should have a minimal impact. Second, this change would remove `SDLConsoleController`, which has remained stagnant for many years. An extensible logging solution would allow others to create something similar to this if desired.
 
-Finally, this proposal would also encompass using this new framework to enhance logging throughout the library using the new log levels and modules, adding log messages throughout the SDL library.
+Finally, this proposal would also encompass using this new framework to enhance logging throughout the library using the new log levels and modules in addition to adding log messages throughout the SDL library.
 
 ## Detailed solution
 Much of this is adapted from a logging library I wrote, [SuperLogger](https://github.com/livio/SuperLogger), which has been open-sourced by Livio.
 
-This proposal would split the logging tool into several classes instead of the current one class. Each destination for a log, e.g. file or console, will be a separate private class. An instance of each class that is actively receiving logs will be held by the central logger controller.
+This proposal would split the logging tool into several classes instead of the current one class. Each destination for a log, e.g. file or console, will be a separate class. An instance of each class that is actively receiving logs will be held by the central logger controller.
 
 ### Logging Controller
-The `SDLLogManager` is a public class that will largely be managed internally but will be the primary place developers would place filters, create modules, set logging level etc. to customize SDL logging. See below for configuration; the `SDLLogManager` will be initialized with this configuration. The `SDLLogManager` will not be managed explicitly by the `SDLLifecycleManager` though it will be started by it. Due to its need to be called globally and for macros to call into it, the `SDLLogManager` will be a singleton object. In `SDLLifecycleManager`'s initialization, it will pass the configuration into the `SDLLogManager`; this means that `SDLLogManager` cannot be used before this point. Since this should be done in the app's `AppDelegate`, this should be very early in the process. This configuration cannot be reset at runtime once it has been set, it will throw an exception if this happens.
+The `SDLLogManager` is a public class that will largely be managed internally but will be the primary place developers would place filters, create modules, set logging level, etc., to customize SDL logging. The `SDLLogManager` will be initialized with a configuration (see below "Configuration"). The `SDLLogManager` will not be managed explicitly by the `SDLLifecycleManager` though it will be started by it. Due to its need to be called globally and for macros to call into it, the `SDLLogManager` will be a singleton object. In `SDLLifecycleManager`'s initialization, it will pass the configuration into the `SDLLogManager`; this means that `SDLLogManager` cannot be used before this point. Since this should be done in the app's `AppDelegate`, this should be very early in the process. This configuration cannot be reset at runtime once it has been set, it will throw an exception if this happens.
 
 The public interface will look something like this:
 
@@ -47,17 +47,13 @@ The public interface will look something like this:
 // Any modules that do not have an explicitly specified level will by default use the global log level;
 @property (assign, nonatomic) SDLLogLevel globalLogLevel;
 
-/**
- *  Shared Controller methods are class methods that automatically target the sharedController instance. Since 99% of the time you will want to use the sharedController, these are considered convenience methods.
++ (SDLLogManager *)sharedManager;
+
+#pragma mark - Singleton methods
+/*
+ * These are automatically called on the `sharedManager`.
  */
-#pragma mark - Shared Controller methods
-
-+ (SDLLogManager *)sharedController;
-
 + (void)startWithConfiguration:(SDLLogConfiguration *)configuration;
-
-+ (void)addFilters:(NSArray<SDLLogFilterBlock> *)filters;
-+ (void)removeFilters:(NSArray<SDLLogFilterBlock> *)filters;
 
 // This would be used internally to send out a log to the loggers
 + (void)logWithLevel:(SDLLogLevel)level
@@ -124,7 +120,7 @@ log.e("Test something \(NSDate())")
 ```
 
 ### Configuration
-The logging system will have an initial configuration of modules and format set by an immutable object `SDLLogConfiguration`, which will be passed to the `SDLConfiguration` upon setting up the `SDLManager`.
+The logging system will have an initial configuration of modules and format set by an immutable object `SDLLogConfiguration`, which will be passed to the `SDLConfiguration` upon setting up the `SDLManager`. `SDLConfiguration` will add a new initializer that may take a `SDLLogConfiguration`; older initializers will set up the default log configuration.
 
 The following will be set up into the configuration ahead of time:
 ```objc
@@ -135,16 +131,16 @@ typedef NS_ENUM(NSUInteger, SDLLogFormatType) {
 };
 
 // Any custom logging modules used by the developer's code. Defaults to none.
-@property (copy, nonatomic, readonly) NSSet<SDLLogFileModule *> *logModules;
+@property (copy, nonatomic) NSSet<SDLLogFileModule *> *logModules;
 
 // Where the logs will attempt to output. Defaults to Console.
-@property (assign, nonatomic, readonly) NSSet<id<SDLLogTarget>> *logTargets;
+@property (assign, nonatomic) NSSet<id<SDLLogTarget>> *logTargets;
 
-// Initial log filters, these will be able to be changed on `SDLLogManager` at runtime. Defaults to none.
-@property (copy, nonatomic, readonly) NSSet<SDLLogFilterBlock> *logFilters;
+// What log filters will run over this session. Defaults to none.
+@property (copy, nonatomic) NSSet<SDLLogFilterBlock> *logFilters;
 
 // How detailed of logs will be output. Defaults to Default.
-@property (assign, nonatomic, readonly) SDLLogFormatType formatType;
+@property (assign, nonatomic) SDLLogFormatType formatType;
 
 // Whether or not logs will be run on a separate queue, asynchronously, allowing the following code to run before the log completes. Or if it will occur synchronously, which will prevent logs from being missed, but will slow down surrounding code. Defaults to YES.
 @property (assign, nonatomic, getter=isAsynchronous) BOOL asynchronous;
@@ -180,7 +176,7 @@ We will provide a few format types:
 #### Macros
 Macros are a way to make it easy to call the logging API while allowing the system to capture almost all of the information for you. Additionally, they are the way of compiling out debug level logs and below in RELEASE mode.
 
-Some of these will be private, as a way for internal SDL logs to more easily be written. Some will be public which will allow developers to call logs pertaining to their SDL integration and have them tie in with the rest of the SDL logging.
+Some of these will be private, as a way for internal SDL logs to more easily be written. Some will be public which will allow developers using Objective-C to call logs pertaining to their SDL integration and have them tie in with the rest of the SDL logging.
 
 ### Logs
 An `SDLLog` object will contain all of the information necessary to format and log a string. This will be a private class. It will contain something like the following properties:
@@ -200,17 +196,8 @@ An `SDLLog` object will contain all of the information necessary to format and l
 - (void)initWith...
 ```
 
-A secondary log type will also be available exclusively for traces that desire to inspect the callstack. This would be useful when it is helpful to know how one got to a particular trace and not just that one got to that point.
-
-```objc
-@interface SDLTraceLog : SDLLog <NSCopying>
-
-@property (copy, nonatomic, readonly) NSArray *callstack;
-```
-
 #### Log Levels
 There are six log levels in order from least important to most important. Setting the system to level "Debug" would output Debug and *above* logs, i.e., Warning, and Error.
-* Trace - A trace does not take any arguments but simply notes the place the trace call was placed and outputs that place was reached.
 * Verbose - A log that is not considered important and is more likely to be noise than helpful.
 * Debug - A log that may be important in debugging situations.
 * Warning - A RELEASE level log that outputs a non-fatal error.
@@ -237,11 +224,11 @@ Console logging (pre-iOS 10) is done through the Syslog APIs, using the `write` 
 #### OS Logging
 `os_log` is an iOS 10+ logging addition that provides several features that would be very helpful for developers such as native filtering and channel support. Because this is iOS 10+ only, if this is activated by the developer on a pre-iOS 10 device, an error message will print and this logging output will be disabled.
 
-We will use [os_log_create](https://developer.apple.com/reference/kernel/1643798-os_log_create?language=objc) to create a channel for SDL specific logging, using categories to align with modules (below) for better filtering.
+We will use [os_log_create](https://developer.apple.com/reference/kernel/1643798-os_log_create?language=objc) to create a channel/subsystem for SDL specific logging, using categories to align with modules (below) for better filtering.
 
-The various levels of logging would correspond with various logging levels (above "Log Types").
+The various levels of logging would correspond with various logging levels (above "Log Types"), probably like this:
 
-* Trace, Verbose - os_log_debug
+* Verbose - os_log_debug
 * Debug - os_log_info
 * Warning - os_log
 * Error - os_log_error
@@ -269,8 +256,14 @@ File logging is currently done with a single file that is overwritten when a new
 @end
 ```
 
+An `SDLLogFilterBlock` takes a log in and returns whether or not the log passes, a `YES` result will log the message:
+
+```objc
+typedef BOOL (^SDLLogFilterBlock)(SDLLog *log);
+```
+
 ### Modules
-`SDLLogFileModule` is a public class allowing developers to tie their own SDL files into modules if desired. All SDL classes will do this by default to enable easier debugging. Modules are groups of files defined ahead of time. A module may have a different logging level than the rest of the system. For example, if the developer wishes to output detailed logs for the file manager, they could specify that the File module use Verbose logging while the rest of SDL and their own code uses a global level of Release.
+`SDLLogFileModule` is a public class allowing developers to tie their own SDL files into modules if desired. All SDL classes will do this by default to enable easier debugging. Modules are groups of files defined ahead of time. A module may have a different logging level than the rest of the system. For example, if the developer wishes to output detailed logs for the file manager, they could specify that the File module use Verbose logging while the rest of SDL and their own code uses a global level of Release. Developers should be able to inspect SDL modules on `SDLLogManager` and alter log levels for internal modules.
 
 ```objc
 @interface SDLLogFileModule : NSObject
@@ -280,8 +273,8 @@ File logging is currently done with a single file that is overwritten when a new
 @property (assign, nonatomic) SDLLogLevel logLevel;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files level:(SDLLogLevel)level NS_DESIGNATED_INITIALIZER;
-- (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files;
+- (instancetype)initWithName:(NSString *)name files:(NSSet<NSString *> *)files level:(SDLLogLevel)level NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(NSString *)name files:(NSSet<NSString *> *)files;
 - (BOOL)containsFile:(NSString *)fileName;
 
 @end
@@ -290,12 +283,12 @@ File logging is currently done with a single file that is overwritten when a new
 ## Potential downsides
 There are a few potential downsides.
 
-1. Adding logs slows down the library? This is largely mitigated in a few ways. First, by compiling out most logs in RELEASE mode, the library will only attempt to log Warning and Error logs for apps in the app store. Second, if developers disable all logging, even release mode logs will only do a quick check and then return. Third, most logs are done asynchronously on a serial dispatch queue and will use a dormant CPU core if available.
+1. Adding logs slows down the library? This is largely mitigated in a few ways. First, by compiling out most logs in RELEASE mode, the library will only attempt to log Warning and Error logs for apps in the app store. Second, if developers disable all logging, even release mode logs will only do a quick check and then return. Third, most logs are done asynchronously on a serial dispatch queue and will use a dormant CPU core if available, the current logger does none of this.
 
-2. Complicated? This proposal is a significantly more complicated solution than the existing logging solution. However, it is not especially complicated and will be rather extensible, allowing us to add additional logger outputs with relative ease. Due to its spread out class structure we can privatize significant portions of the library and leaving only the API surface necessary for developers to interact with as public.
+2. Complicated? This proposal has significantly more parts than the existing logging solution. However, it is not especially complicated and will be rather extensible, allowing us to add additional logger outputs with relative ease. Due to its spread out class structure we can privatize significant portions of the library and leaving only the API surface necessary for developers to interact with as public.
 
 ## Impact on existing code
-Removing `SDLDebugTool` and `SDLConsoleController` would cause a major version change. Adding additional logs throughout the entire SDL library may slow the library down slightly to perform those logs; however, since the logs would mostly be Debug and below level logs, those logs will be compiled out of RELEASE mode, and the remaining logs (primarily errors) can be turned off by the developer, causing a minimal performance hit. This is very likely to be more performant than current logging in any case.
+Removing `SDLDebugTool` and `SDLConsoleController` would cause a major version change. Adding additional logs throughout the entire SDL library may slow the library down slightly to perform those logs; however, since the logs would mostly be Debug and below level logs, those logs will be compiled out of RELEASE mode. The remaining logs (primarily errors) can be turned off by the developer, causing a minimal performance hit. This is very likely to be more performant than current logging in any case.
 
 ## Alternatives considered
 The major alternative would be to use a third party library to provide similar functionality without having to develop it ourselves. However, that would cause us to have a 3rd party dependency, which may not be desirable.

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -17,7 +17,7 @@ The proposed solution is to provide a few additional features:
 * Most logs (see "Detailed solution") disabled when the app is created in `RELEASE` mode instead of `DEBUG`.
 * Provide multiple levels of logging, such as `Verbose` (see below, "Detailed solution" for a full list).
 * Better log formatting with simple and detailed logs, providing features such as which queue, file, method, and module the log was sent on.
-* Async logging support, with errors being synchronous.
+* Async by default logging, with error logs being synchronous by default.
 * Filters allow only logs that pass a check to actually be logged.
 
 This proposal is a major version change because it would remove two classes, `SDLDebugTool` is the currently logging class, however, it is unlikely to be used directly by the developer. Second, this change would remove `SDLConsoleController`, which has remained stagnant for many years. An extensible logging solution would allow others to create something similar to this if desired.

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -169,10 +169,10 @@ Developers using Objective-C (macros are Obj-C only) will be able to call logs p
 There will be separate macros for each logging level, similar to "Swift Support" above.
 
 ```objc
-SDLLogV("Test verbose");
-SDLLogD("Test debug");
-SDLLogW("Test warning");
-SDLLogE("Test error");
+SDLLogV(@"Test verbose");
+SDLLogD(@"Test debug");
+SDLLogW(@"Test warning");
+SDLLogE(@"Test error");
 ```
 
 ### Logs

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -15,7 +15,7 @@ The current system was written quite a long time ago and is not particularly fas
 The proposed solution is to provide a few additional features:
 
 * Most logs (see "Detailed solution") disabled when the app is created in `RELEASE` mode instead of `DEBUG`.
-* Provide multiple levels of logging, such as `Verbose` (see below, "Detailed solution,"" for a full list).
+* Provide multiple levels of logging, such as `Verbose` (see below, "Detailed solution" for a full list).
 * Better log formatting with simple and detailed logs, providing features such as which queue, file, method, and module the log was sent on.
 * Async logging support, with errors being synchronous.
 * Filters allow only logs that pass a check to actually be logged.

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -194,7 +194,7 @@ An `SDLLogModel` object will contain all of the information necessary to format 
 ```
 
 #### Log Levels
-There are six log levels in order from least important to most important. Setting the system to level "Debug" would output Debug and *above* logs, i.e., Warning, and Error.
+There are four log levels in order from least important to most important. Setting the system to level "Debug" would output Debug and *above* logs, i.e., Warning, and Error.
 * Verbose - A log that is not considered important and is more likely to be noise than helpful.
 * Debug - A log that may be important in debugging situations.
 * Warning - A RELEASE level log that outputs a non-fatal error.

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -80,16 +80,6 @@ The public interface will look something like this:
 To support Swift developers well, we will need to support an additional framework, `SDLLoggerSwift` that Swift developers may import (or copy into their project, as it is a single file). This is necessary because for the code to work well in Swift, it will need to be written in Swift. If it is not written in Swift, we will not be able to automatically pull file / function / line information as we can when Obj-C developers use the macros. The Swift file would look like this:
 
 ```swift
-//
-//  SuperLoggerSwift.swift
-//  SuperLogger
-//
-//  Created by Joel Fischer on 2/13/17.
-//  Copyright © 2017 livio. All rights reserved.
-//
-
-import Foundation
-import SuperLogger
 
 open class SDLLoggerSwift {
     open class func v(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -1,0 +1,241 @@
+# Redesign iOS Logging
+
+* Proposal: [SDL-NNNN](nnnn-ios-logging-redesign.md)
+* Author: [Joel Fischer](https://github.com/joeljfischer), [Alex Muller](https://github.com/asm09fsu)
+* Status: **Awaiting review**
+* Impacted Platforms: iOS
+
+## Introduction
+This proposal is a full redesign of the internal logging framework used by SDL, `SDLDebugTool`. The goal is to provide flexible and fast logging for internal and related developer usage.
+
+## Motivation
+The current system was written quite a long time ago and is not particularly fast, nor flexible. It provides some basic file logging and console logging, but does not provide a developer many options to log related logs or to customize and filter the output as desired.
+
+## Proposed solution
+The proposed solution is to provide a few additional features:
+
+* Most logs (see "Detailed solution") disabled when the app is created in `RELEASE` mode instead of `DEBUG`.
+* Provide multiple levels of logging, such as `Verbose` (see below, "Detailed solution,"" for a full list).
+* Better log formatting with simple and detailed logs, providing features such as which queue, file, method, and module the log was sent on.
+* Async logging support, with errors being synchronous.
+* Filters allow only logs that pass a check to actually be logged.
+
+This proposal is a major version change because it would remove two classes, `SDLDebugTool` is the currently logging class, however, it is unlikely to be used directly by the developer. Second, this change would remove `SDLConsoleController`, which has remained stagnant for many years and nobody the author is aware of uses.
+
+## Detailed solution
+Much of this is adapted from a logging library I wrote, [SuperLogger](https://github.com/livio/SuperLogger), which has been open-sourced by Livio.
+
+This proposal would split the logging tool into several classes instead of the current one class. Each destination for a log, e.g. file or console, will be a separate private class. An instance of each class that is actively receiving logs will be held by the central logger controller.
+
+### Logging Controller
+The `SDLLogManager` is a public class that will largely be managed internally but will be the primary place developers would place filters, create modules, set logging level etc. to customize SDL logging. See below for configuration; the `SDLLogManager` will be initialized with this configuration. The `SDLLogManager` will not be managed explicitly by the `SDLLifecycleManager` though it will be started by it. Due to its need to be called globally and for macros to call into it, the `SDLLogManager` will be a singleton object. In `SDLLifecycleManager`'s initialization, it will pass the configuration into the `SDLLogManager`; this means that `SDLLogManager` cannot be used before this point. Since this should be done in the app's `AppDelegate`, this should be very early in the process. This configuration cannot be reset at runtime once it has been set, it will throw an exception if this happens.
+
+The public interface will look something like this:
+
+```objc
+@interface SDLLogManager : NSObject
+
+@property (copy, nonatomic, readonly) NSSet<SDLLogFileModule *> *logModules;
+@property (assign, nonatomic, readonly) SDLLogOutput *logOutput;
+@property (copy, nonatomic, readonly) NSSet<SDLLogFilterBlock> *logFilters;
+
+@property (assign, nonatomic, readonly) BOOL async;
+@property (assign, nonatomic, readonly) BOOL errorAsync;
+
+// Any modules that do not have an explicitly specified level will by default use the global log level;
+@property (assign, nonatomic) SLLogLevel globalLogLevel;
+
+/**
+ *  Shared Controller methods are class methods that automatically target the sharedController instance. Since 99% of the time you will want to use the sharedController, these are considered convenience methods.
+ */
+#pragma mark - Shared Controller methods
+
++ (SLLoggerController *)sharedController;
+
++ (void)startWithConfiguration:(SDLLogConfiguration *)configuration;
+
++ (void)addFilters:(NSArray<SDLLogFilterBlock> *)filters;
++ (void)removeFilters:(NSArray<SDLLogFilterBlock> *)filters;
+
++ (void)logWithLevel:(SLLogLevel)level
+            fileName:(NSString *)fileName
+        functionName:(NSString *)functionName
+                line:(NSInteger)line
+             message:(NSString *)message, ... NS_FORMAT_FUNCTION(5, 6);
+
+@end
+```
+
+### Configuration
+The logging system will have an initial configuration of modules and format set by an immutable object `SDLLogConfiguration`, which will be passed to the `SDLConfiguration` upon setting up the `SDLManager`.
+
+The following will be set up into the configuration ahead of time:
+```objc
+typedef NS_OPTIONS(NSUInteger, SDLLogOutput) {
+    SDLLogOutputNone = 0,
+    SDLLogOutputConsole = 1 << 0,
+    SDLLogOutputFile = 1 << 1,
+    SDLLogOutputOSLog = 1 << 2,
+};
+
+typedef NS_ENUM(NSUInteger, SDLLogFormatType) {
+    SDLLogFormatTypeSimple,
+    SDLLogFormatTypeDefault,
+    SDLLogFormatTypeDetailed,
+};
+
+// Any custom logging modules used by the developer's code. Defaults to none.
+@property (copy, nonatomic, readonly) NSSet<SDLLogFileModule *> *logModules;
+
+// Where the logs will attempt to output. Defaults to Console.
+@property (assign, nonatomic, readonly) SDLLogOutput *logOutput;
+
+// Initial log filters, these will be able to be changed on `SDLLogManager` at runtime. Defaults to none.
+@property (copy, nonatomic, readonly) NSSet<SLLogFilterBlock> *logFilters;
+
+// How detailed of logs will be output. Defaults to Default.
+@property (assign, nonatomic, readonly) SDLLogFormatType formatType;
+
+// Whether or not logs will be run on a separate queue, asynchronously, allowing the following code to run before the log completes. Or if it will occur synchronously, which will prevent logs from being missed, but will slow down surrounding code. Defaults to YES.
+@property (assign, nonatomic) BOOL async;
+
+// Whether or not error logs will be dispatched to loggers asynchronously. Defaults to NO.
+@property (assign, nonatomic) BOOL errorAsync;
+
+ // Any modules that do not have an explicitly specified level will by default use the global log level. Defaults to Error.
+@property (assign, nonatomic) SDLLogLevel globalLogLevel;
+```
+
+### Formatting
+We will provide a few format types:
+
+**Simple**
+```objc
+[NSString stringWithFormat:@"%@ (SDL)%@ %@ – %@\n", dateString, logCharacter, moduleName, message];
+09:52:07:324 🔹 (SDL)Protocol – a random test i guess
+```
+
+**Default**
+```objc
+[NSString stringWithFormat:@"%@ (%@:%@:L%ld) %@\n", dateString, logCharacter, moduleName, fileName, (long)line, message];
+09:52:07:324 🔹 (SDL)Protocol:SDLV2ProtocolHeader:25 – Some log message
+```
+
+**Detailed**
+```objc
+[NSString stringWithFormat:@"%@ (%@ : %@ : %@ : L%ld) %@\n", dateString, logCharacter, logLevelString, queueLabel, moduleName, functionName, (long)line, message];
+09:52:07:324 🔹 DEBUG com.apple.main-thread:(SDL)Protocol:[SDLV2ProtocolHeader parse:]:74) – Some log message
+```
+
+#### Macros
+Macros are a way to make it easy to call the logging API while allowing the system to capture almost all of the information for you. Additionally, they are the way of compiling out debug level logs and below in RELEASE mode.
+
+Some of these will be private, as a way for internal SDL logs to more easily be written. Some will be public which will allow developers to call logs pertaining to their SDL integration and have them tie in with the rest of the SDL logging.
+
+### Logs
+An `SDLLog` object will contain all of the information necessary to format and log a string. This will be a private class. It will contain something like the following properties:
+
+```objc
+@interface SDLLog : NSObject <NSCopying>
+
+@property (copy, nonatomic, readonly) NSString *message;
+@property (copy, nonatomic, readonly) NSDate *timestamp;
+@property (assign, nonatomic, readonly) SDLLogLevel level;
+@property (copy, nonatomic, readonly) NSString *queueLabel;
+@property (copy, nonatomic, readonly) NSString *moduleName;
+@property (copy, nonatomic, readonly) NSString *fileName;
+@property (copy, nonatomic, readonly) NSString *functionName;
+@property (assign, nonatomic, readonly) NSInteger line;
+
+- (void)initWith...
+```
+
+A secondary log type will also be available exclusively for traces that desire to inspect the callstack. This would be useful when it is helpful to know how one got to a particular trace and not just that one got to that point.
+
+```objc
+@interface SDLTraceLog : SDLLog <NSCopying>
+
+@property (copy, nonatomic, readonly) NSArray *callstack;
+```
+
+#### Log Levels
+There are six log levels in order from least important to most important. Setting the system to level "Debug" would output Debug and *above* logs, i.e. Release and Error.
+* Trace - A trace does not take any arguments but simply notes the place the trace call was placed and outputs that place was reached.
+* Verbose - A log that is not considered at all
+* Debug
+* Release
+* Warning
+* Error
+
+### Logging Targets
+There would initially be three logging targets that may be enabled by the developer. Each of these will be private classes, they will be enabled via an `NS_OPTIONS` switch.
+
+#### Console Logging
+Console logging (pre-iOS 10) is done through the Syslog APIs, using the `write` function. This will simply take the formatted string and log it.
+
+#### File Logging
+File logging is currently done with a single file that is overwritten when a new `SDLManager` is initialized. The new system would keep a rolling log of three files in a directory with files sorted by file name – the current timestamp.
+
+#### OS Logging
+`os_log` is an iOS 10+ logging addition that provides several features that would be very helpful for developers such as native filtering and channel support. Because this is iOS 10+ only, if this is activated by the developer on a pre-iOS 10 device, an error message will print and this logging output will be disabled.
+
+We will use [os_log_create](https://developer.apple.com/reference/kernel/1643798-os_log_create?language=objc) to create a channel for SDL specific logging, using categories to align with modules (below) for better filtering.
+
+The various levels of logging would correspond with various logging levels (above "Log Types").
+
+* Trace, Verbose - os_log_debug
+* Debug - os_log_info
+* Release - os_log
+* Warning - os_log
+* Error - os_log_error
+
+### Filtering
+`SDLLogFilter` will be a public class allowing developers to filter logs to only allow specific ones. This will be useful for debugging. Filtering allows the developer to have logs pass a check before they are able to be logged. This would be by allowing / disallowing logs that have a message containing a string or passing a regex check, or allowing / disallowing certain modules, files, or queues. It may look something like this:
+
+```objc
+@interface SDLLogFilter : NSObject
+
++ (SDLLogFilterBlock)filterByDisallowingString:(NSString *)string caseInsensitive:(BOOL)caseInsensitive;
++ (SDLLogFilterBlock)filterByAllowingString:(NSString *)string caseInsensitive:(BOOL)caseInsensitive;
++ (SDLLogFilterBlock)filterByDisallowingRegex:(NSRegularExpression *)regex;
++ (SDLLogFilterBlock)filterByAllowingRegex:(NSRegularExpression *)regex;
++ (SDLLogFilterBlock)filterByAllowingModules:(NSSet<SLFileModule *> *)modules;
++ (SDLLogFilterBlock)filterByDisallowingModules:(NSSet<SLFileModule *> *)modules;
++ (SDLLogFilterBlock)filterByAllowingFileNames:(NSSet<NSString *> *)fileNames;
++ (SDLLogFilterBlock)filterByDisallowingFileNames:(NSSet<NSString *> *)fileNames;
++ (SDLLogFilterBlock)filterByAllowingQueues:(NSSet<NSString *> *)queueNames;
++ (SDLLogFilterBlock)filterByDisallowingQueues:(NSSet<NSString *> *)queueNames;
+
+@end
+```
+
+### Modules
+`SDLLogFileModule` is a public class allowing developers to tie their own SDL files into modules if desired. All SDL classes will do this by default to enable easier debugging. Modules are groups of files defined ahead of time. A module may have a different logging level than the rest of the system. For example, if the developer wishes to output detailed logs for the file manager, they could specify that the File module use Verbose logging while the rest of SDL and their own code uses a global level of Release.
+
+```objc
+@interface SDLLogFileModule : NSObject
+
+@property (copy, nonatomic, readonly) NSString *name;
+@property (copy, nonatomic, readonly) NSSet<NSString *> *files;
+@property (assign, nonatomic) SLLogLevel logLevel;
+
+- (instancetype)init NS_UNAVAILABLE;
+- (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files level:(SLLogLevel)level NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithName:(NSString *)name files:(NSArray<NSString *> *)files;
+- (BOOL)containsFile:(NSString *)fileName;
+
+@end
+```
+
+## Potential downsides
+There are a few potential downsides.
+
+1. Adding logs slows down the library? This is largely mitigated in a few ways. First, by compiling out most logs in RELEASE mode, the library will only attempt to log Release, Warning, and Error logs for apps in the app store. Second, if developers disable all logging, even release mode logs will only do a quick check and then return. Third, most logs are done asynchronously on a serial dispatch queue and will use a dormant CPU core if available.
+
+2. Complicated? This proposal is a significantly more complicated solution than the existing logging solution. However, it is not especially complicated and will be rather extensible, allowing us to add additional logger outputs with relative ease. Due to its spread out class structure we can privatize significant portions of the library and leaving only the API surface necessary for developers to interact with as public.
+
+## Impact on existing code
+Removing `SDLDebugTool` and `SDLConsoleController` would cause a major version change. Adding additional logs throughout the entire SDL library may slow the library down slightly to perform those logs; however, since the logs would mostly be Debug and below level logs, those logs will be compiled out of RELEASE mode, and the remaining logs (primarily errors) can be turned off by the developer, causing a minimal performance hit.
+
+## Alternatives considered
+The major alternative would be to use a third party library to provide similar functionality without having to develop it ourselves. However, that would cause us to have a 3rd party dependency, which may not be desirable.

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -78,35 +78,23 @@ To support Swift developers well, we will need to support an additional framewor
 ```swift
 
 open class SDLLoggerSwift {
+    // Verbose
     open class func v(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
-        verbose(message, file, function, line)
-    }
-
-    open class func verbose(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
         SDLLogManager.log(with: .verbose, fileName: file, functionName: function, line: line, message: "\(message())")
     }
 
+    // Debug
     open class func d(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
-        debug(message, file, function, line)
-    }
-
-    open class func debug(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
         SDLLogManager.log(with: .debug, fileName: file, functionName: function, line: line, message: "\(message())")
     }
 
+    // Warning
     open class func w(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
-        warning(message, file, function, line)
-    }
-
-    open class func warning(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
         SDLLogManager.log(with: .warning, fileName: file, functionName: function, line: line, message: "\(message())")
     }
 
+    // Error
     open class func e(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
-        error(message, file, function, line)
-    }
-
-    open class func error(_ message: @autoclosure () -> Any, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
         SDLLogManager.log(with: .error, fileName: file, functionName: function, line: line, message: "\(message())")
     }
 }

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -1,7 +1,7 @@
 # Redesign iOS Logging
 
 * Proposal: [SDL-NNNN](nnnn-ios-logging-redesign.md)
-* Author: [Joel Fischer](https://github.com/joeljfischer), [Alex Muller](https://github.com/asm09fsu)
+* Author: [Joel Fischer](https://github.com/joeljfischer)
 * Status: **Awaiting review**
 * Impacted Platforms: iOS
 

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -9,7 +9,7 @@
 This proposal is a full redesign of the internal logging framework used by SDL, `SDLDebugTool`. The goal is to provide flexible and fast logging for internal and related developer usage.
 
 ## Motivation
-The current system was written quite a long time ago and is not particularly fast, nor flexible. It provides some basic file logging and console logging, but does not provide a developer many options to log related logs or to customize and filter the output as desired.
+The current system was written quite a long time ago and is not particularly fast, nor flexible. It provides some basic file logging and console logging, but does not provide a developer many options to log related logs or to customize and filter the output as desired. We need a better logging framework in order to add more logs than currently exist, make sure they're fast, and provide developers with the tools and flexibility to debug their code.
 
 ## Proposed solution
 The proposed solution is to provide a few additional features:

--- a/proposals/nnnn-ios-logging-redesign.md
+++ b/proposals/nnnn-ios-logging-redesign.md
@@ -176,7 +176,16 @@ We will provide a few format types:
 #### Macros
 Macros are a way to make it easy to call the logging API while allowing the system to capture almost all of the information for you. Additionally, they are the way of compiling out debug level logs and below in RELEASE mode.
 
-Some of these will be private, as a way for internal SDL logs to more easily be written. Some will be public which will allow developers using Objective-C to call logs pertaining to their SDL integration and have them tie in with the rest of the SDL logging.
+Developers using Objective-C (macros are Obj-C only) will be able to call logs pertaining to their SDL integration and have them tie in with the rest of the SDL logging.
+
+There will be separate macros for each logging level, similar to "Swift Support" above.
+
+```objc
+SDLLogV("Test verbose");
+SDLLogD("Test debug");
+SDLLogW("Test warning");
+SDLLogE("Test error");
+```
 
 ### Logs
 An `SDLLog` object will contain all of the information necessary to format and log a string. This will be a private class. It will contain something like the following properties:


### PR DESCRIPTION
This proposal is a full redesign of the internal logging framework used by SDL, `SDLDebugTool`. The goal is to provide flexible and fast logging for internal and related developer usage.