### PR TITLE
SDL must transfer RPC with non-existed Image

### DIFF
--- a/proposals/NNN-sdl-must-transfer-rpc-with-non-existed-image.md
+++ b/proposals/NNN-sdl-must-transfer-rpc-with-non-existed-image.md
@@ -1,0 +1,32 @@
+# SDL must transfer RPC with non-existed "Image" to HMI
+
+* Proposal: SDL-NNNN
+* Author: Melnyk Tetiana
+* Status: Awaiting review
+* Impacted Platforms: Core / RPC
+
+## Introduction
+
+To change SDL behavior in case requested by app "Image" does NOT exist at "AppStorageFolder"
+
+## Motivation
+
+Currently SDL invalidates or rejects all RPC requested "Image" that does NOt exist at apps "AppStorageFolder"
+
+## Proposed solution
+
+SDL must transfer all RPCs to HMI for processing even if "Image" does NOT exist/was not uploaded before this request
+
+## Detailed design
+
+App requests "Image" via any applicable RPC. SDL checks "Image" - does NOT exist at "AppStorageFolder". SDL transfers this RPC to HMI for processing.
+Expected resultCode from HMI is "WARNINGS" + "message: Requested image(s) does not exist"
+
+## Impact on existing code
+
+SDL behavior only
+
+## Alternatives considered
+
+TBD
+

--- a/proposals/NNN-sdl-must-transfer-rpc-with-non-existed-image.md
+++ b/proposals/NNN-sdl-must-transfer-rpc-with-non-existed-image.md
@@ -19,12 +19,36 @@ SDL must transfer all RPCs to HMI for processing even if "Image" does NOT exist/
 
 ## Detailed design
 
-App requests "Image" via any applicable RPC. SDL checks "Image" - does NOT exist at "AppStorageFolder". SDL transfers this RPC to HMI for processing.
-Expected resultCode from HMI is "WARNINGS" + "message: Requested image(s) does not exist"
+* App -> SDL: RPC (<Image>)
+* SDL checks that <Image> does NOT exist at AppStorageFolder for this app
+
+* SDL -> HMI: RPC (<Image>)
+* HMI processes this RPC
+
+* HMI -> SDL: RPC (WARNINGS, message: “Requested image(s) is not found”) //in case of NO any failures
+
+* SDL -> app: RPC (WARNINGS, info: “Requested image(s) is not found”)
+
 
 ## Impact on existing code
 
-SDL behavior only
+The following RPCs will be impacted:
+* 1. SendLocation
+* 2. ShowConstantTBT
+* 3. PerformAudioPassThru
+* 4. Show
+* 5. AddSubMenu
+* 6. AddCommand
+* 7. SetGlobalProperties
+* 8. OnWayPointChange
+* 9. GetWayPoints_response
+* 10. UpdateTurnList
+* 11. PerformInteraction
+* 12. AlertManeuver
+* 13. ShowConstantTBT
+* 14. ScrollableMessage
+* 15. Alert
+
 
 ## Alternatives considered
 


### PR DESCRIPTION
Currently SDL invalidates RPC with non-existed Image
This behavior must be changed - proposal to transfer such RPCs to HMI for processing