### PR TITLE
Locale support

### DIFF
--- a/proposals/NNNN-locale-support.md
+++ b/proposals/NNNN-locale-support.md
@@ -15,9 +15,7 @@ SDL is not flexible in adding new languages or countries. It requires changes to
 
 ## Proposed solution
 
-The proposed solution is to fully remove the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR.  Using unicode would allow SDL adopters to be more flexible but still follow a standard to agree to language codes.
-
-Unicode locale allows the head unit to provide the script name which can help the app to 
+The proposed solution is to deprecate the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR. Using unicode would allow SDL adopters to be more flexible but still follow a standard to agree to language codes.
 
 ### Mobile and HMI API
 
@@ -37,9 +35,9 @@ As a replacement to `language` and `languageDesired` new string parameters calle
 
 ### Core & HMI 
 
-Core and HMI should continue to send the language parameters if the head unit is configured to a language which is known within the `Language` enum otherwise they should omit the language parameter from the JSON data. They should be always sending the locale parameter regardless of if the language is known by the enum.
+Core and HMI should continue to send the language parameters if the head unit is configured to a language which is known within the `Language` enum otherwise they should omit the `language` parameter from the JSON data. They should be always sending the `locale` parameter regardless of if the language is known by the enum.
 
-The locale parameters should follow the syntax of locale names. 
+The `locale` parameters should follow the syntax of locale names. 
 
 > The identifiers can vary in case and in the separator characters. The "-" and "_" separators are treated as equivalent. All identifier field values are case-insensitive. Although case distinctions do not carry any special meaning, an implementation of LDML should use the casing recommendations in [BCP47], especially when a Unicode locale identifier is used for locale data exchange in software protocols. The recommendation is that: the region subtag is in uppercase, the script subtag is in title case, and all other subtags are in lowercase.
 
@@ -51,7 +49,7 @@ The SDKs should follow the changes as per mobile API but the `locale` properties
 
 The Android SDK should create a locale object by using the static method `Locale.forLanguageTag`. The iOS SDK should create a locale object by using the initializer `initWithLocaleIdentifier:`. 
 
-Depending on the JSON data as the input for the Locale object the SDK should use the `locale` parameter by default. If the JSON data does not contain a `locale` parameter the SDK should use the `language` parameter instead to keep backwards compatibility. If necessary the SDK should modify the `language` String to match the syntax of locale names ("EN_US" > "en-US").
+Depending on the JSON data the SDK should use the `locale` parameter as the input for the Locale object by default. If the JSON data does not contain a `locale` parameter the SDK should use the `language` parameter instead to keep backwards compatibility. If necessary the SDK should modify the `language` String to match the syntax of locale names ("EN_US" > "en-US").
 
 ## Potential downsides
 

--- a/proposals/NNNN-locale-support.md
+++ b/proposals/NNNN-locale-support.md
@@ -1,0 +1,60 @@
+# Locale support
+
+* Proposal: [SDL-NNNN](NNNN-locale-support.md)
+* Author: [Kujtim Shala](https://github.com/kshala-ford)
+* Status: **Awaiting review**
+* Impacted Platforms: [Core / iOS / Android / Web / RPC ]
+
+## Introduction
+
+This proposal is about changing the way how SDL treats languages and localizations. The idea is to replace the `Language` enum and use the Locale structure/class of the native SDKs.
+
+## Motivation
+
+SDL is not flexible in adding new languages or countries. It requires changes to the HMI and mobile API as well as SDL core. 
+
+## Proposed solution
+
+The proposed solution is to fully remove the `Language` enum. Instead a locale structure should be added that follows locale names defined by the unicode CLDR.
+
+### Mobile and HMI API
+
+The `Language` enum should be completely removed with no replacement.
+
+```xml
+- <enum name="Language">
+-   <element ....>
+-   </element>
+- ...
+- </enum>
+```
+
+Every existing parameter of type `Language` should be changed to the type `String`. Following parameters are affected:
+
+- KeyboardProperties.language
+- RegisterAppInterface.languageDesired
+- RegisterAppInterface.hmiDisplayLanguageDesired
+- RegisterAppInterfaceResponse.language
+- RegisterAppInterfaceResponse.hmiDisplayLanguage
+- ChangeRegistration.language
+- ChangeRegistration.hmiDisplayLanguage
+- OnLanguageChange.language
+- OnLanguageChange.hmiDisplayLanguage
+
+### SDKs
+
+The 
+
+Describe the design of the solution in detail. Use subsections to describe various details. If it involves new protocol changes or RPC changes, show the full XML of all changes and how they changed. Show documentation comments detailing what it does. Show how it might be implemented on the Mobile Library and Core. The detail in this section should be sufficient for someone who is *not* one of the authors to be able to reasonably implement the feature and future [smartdevicelink.com](https://www.smartdevicelink.com) guides.
+
+## Potential downsides
+
+Describe any potential downsides or known objections to the course of action presented in this proposal, then provide counter-arguments to these objections. You should anticipate possible objections that may come up in review and provide an initial response here. Explain why the positives of the proposal outweigh the downsides, or why the downside under discussion is not a large enough issue to prevent the proposal from being accepted.
+
+## Impact on existing code
+
+Describe the impact that this change will have on existing code. Will some SDL integrations stop compiling due to this change? Will applications still compile but produce different behavior than they used to? Is it possible to migrate existing SDL code to use a new feature or API automatically?
+
+## Alternatives considered
+
+Describe alternative approaches to addressing the same problem, and why you chose this approach instead.

--- a/proposals/NNNN-locale-support.md
+++ b/proposals/NNNN-locale-support.md
@@ -47,7 +47,7 @@ See http://www.unicode.org/reports/tr35/tr35-47/tr35.html#Unicode_Language_and_L
 
 ### SDKs
 
-The SDKs should follow the changes as per mobile API but the `locale` properties should be of type (NSLocale)[https://developer.apple.com/reference/foundation/nslocale] for iOS or [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android instead of String.
+The SDKs should follow the changes as per mobile API but the `locale` properties should be of type [NSLocale](https://developer.apple.com/reference/foundation/nslocale) for iOS or [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android instead of String.
 
 The Android SDK should create a locale object by using the static method `Locale.forLanguageTag`. The iOS SDK should create a locale object by using the initializer `initWithLocaleIdentifier:`. 
 

--- a/proposals/NNNN-locale-support.md
+++ b/proposals/NNNN-locale-support.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-NNNN](NNNN-locale-support.md)
 * Author: [Kujtim Shala](https://github.com/kshala-ford)
 * Status: **Awaiting review**
-* Impacted Platforms: [Core / iOS / Android / Web / RPC ]
+* Impacted Platforms: [Core / iOS / Android / RPC ]
 
 ## Introduction
 
@@ -11,25 +11,17 @@ This proposal is about changing the way how SDL treats languages and localizatio
 
 ## Motivation
 
-SDL is not flexible in adding new languages or countries. It requires changes to the HMI and mobile API as well as SDL core. 
+SDL is not flexible in adding new languages or countries. It requires changes to the HMI and mobile API as well as SDL core. Furthermore it would be counterproductive to enumerate all possible variations of language and country SDL should support.
 
 ## Proposed solution
 
-The proposed solution is to fully remove the `Language` enum. Instead a locale structure should be added that follows locale names defined by the unicode CLDR.
+The proposed solution is to fully remove the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR.  Using unicode would allow SDL adopters to be more flexible but still follow a standard to agree to language codes.
+
+Unicode locale allows the head unit to provide the script name which can help the app to 
 
 ### Mobile and HMI API
 
-The `Language` enum should be completely removed with no replacement.
-
-```xml
-- <enum name="Language">
--   <element ....>
--   </element>
-- ...
-- </enum>
-```
-
-Every existing parameter of type `Language` should be changed to the type `String`. Following parameters are affected:
+The `Language` enum should be deprecated with no replacement. Every existing parameter of type `Language` should be deprecated. Furthermore they should be all optional. Making those parameters optional allows the use of unknown languages. Following parameters are affected:
 
 - KeyboardProperties.language
 - RegisterAppInterface.languageDesired
@@ -41,20 +33,34 @@ Every existing parameter of type `Language` should be changed to the type `Strin
 - OnLanguageChange.language
 - OnLanguageChange.hmiDisplayLanguage
 
+As a replacement to `language` and `languageDesired` new string parameters called `locale` and `localeDesired` should be added. The legacy parameter `hmiDisplayLanguage` and `hmiDisplayLanguageDesired` should not be replaced. 
+
+### Core & HMI 
+
+Core and HMI should continue to send the language parameters if the head unit is configured to a language which is known within the `Language` enum otherwise they should omit the language parameter from the JSON data. They should be always sending the locale parameter regardless of if the language is known by the enum.
+
+The locale parameters should follow the syntax of locale names. 
+
+> The identifiers can vary in case and in the separator characters. The "-" and "_" separators are treated as equivalent. All identifier field values are case-insensitive. Although case distinctions do not carry any special meaning, an implementation of LDML should use the casing recommendations in [BCP47], especially when a Unicode locale identifier is used for locale data exchange in software protocols. The recommendation is that: the region subtag is in uppercase, the script subtag is in title case, and all other subtags are in lowercase.
+
+See http://www.unicode.org/reports/tr35/tr35-47/tr35.html#Unicode_Language_and_Locale_Identifiers
+
 ### SDKs
 
-The 
+The SDKs should follow the changes as per mobile API but the `locale` properties should be of type (NSLocale)[https://developer.apple.com/reference/foundation/nslocale] for iOS or [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android instead of String.
 
-Describe the design of the solution in detail. Use subsections to describe various details. If it involves new protocol changes or RPC changes, show the full XML of all changes and how they changed. Show documentation comments detailing what it does. Show how it might be implemented on the Mobile Library and Core. The detail in this section should be sufficient for someone who is *not* one of the authors to be able to reasonably implement the feature and future [smartdevicelink.com](https://www.smartdevicelink.com) guides.
+The Android SDK should create a locale object by using the static method `Locale.forLanguageTag`. The iOS SDK should create a locale object by using the initializer `initWithLocaleIdentifier:`. 
+
+Depending on the JSON data as the input for the Locale object the SDK should use the `locale` parameter by default. If the JSON data does not contain a `locale` parameter the SDK should use the `language` parameter instead to keep backwards compatibility. If necessary the SDK should modify the `language` String to match the syntax of locale names ("EN_US" > "en-US").
 
 ## Potential downsides
 
-Describe any potential downsides or known objections to the course of action presented in this proposal, then provide counter-arguments to these objections. You should anticipate possible objections that may come up in review and provide an initial response here. Explain why the positives of the proposal outweigh the downsides, or why the downside under discussion is not a large enough issue to prevent the proposal from being accepted.
+The language parameters are mandatory for existing SDL integrations (Ford SYNC1 & SYNC3 with AppLink). Therefore they should be deprecated but still available for a long period of time until a threshold of active head units with locale support is reached. This threshold should be quite high (>90%) and may require years to happen.
 
 ## Impact on existing code
 
-Describe the impact that this change will have on existing code. Will some SDL integrations stop compiling due to this change? Will applications still compile but produce different behavior than they used to? Is it possible to migrate existing SDL code to use a new feature or API automatically?
+The impact on existing code is quite high for mobile apps. Every app uses language parameters at least to register on the head unit. 
 
 ## Alternatives considered
 
-Describe alternative approaches to addressing the same problem, and why you chose this approach instead.
+The alternative is to keep the enum and add every necessary language/region combination. This could end up with a very huge Language enum.


### PR DESCRIPTION
This proposal is about changing the way how SDL treats languages and localizations. The idea is to replace the `Language` enum and use the Locale structure/class of the native SDKs.