### PR TITLE
Add H.264 over RTP format support for video streaming

### DIFF
--- a/proposals/0048-H264-over-RTP-support-for-video-streaming.md
+++ b/proposals/0048-H264-over-RTP-support-for-video-streaming.md
@@ -2,7 +2,7 @@
 
 * Proposal: [SDL-0048](0048-H264-over-RTP-support-for-video-streaming.md)
 * Author: [Sho Amano](https://github.com/shoamano83)
-* Status: **Deferred**
+* Status: **Awaiting Review**
 * Impacted Platforms: [Core / iOS / Android / RPC / Protocol]
 
 ## Introduction


### PR DESCRIPTION
This proposal aims to achieve more robust and smooth video streaming for navigation and projection by adding timestamp information to a video stream.