### PR TITLE
SDL 0061 Locale Support

### DIFF
--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -178,32 +178,32 @@ The proposed solution is to deprecate the `Language` enum. Instead the locale st
 </function>
 ```
 
-### Core
+### Locale format
 
-Depending on the app registration Core should be using the old `language` parameters or the new `locale` parameters.
-
-Example (assuming Locale support is implemented in version 4.5 of the mobile API):
-- An app registers using `RegisterAppInterface` with 
-    - `.sdlMsgVersion` set to `4.5.0` and
-    - `.localeDesired` set to `en-US` and
-    - `.languageDesired` set to a matching `Language.EN_US`
-- Core expects the app is working with locale parameters 
-- Core replies using `.locale` parameter instead of `.language` parameter.
-- If the language 
-
-If the head unit is configured to a locale which is listed in the `Language` enum the deprecated parameters should be set to that enum value. Otherwise `EN_US` should be used as a fallback.
-
-The `locale` parameters should follow the syntax of locale names. 
+The `.locale` parameters should follow the syntax of locale names. 
 
 > The identifiers can vary in case and in the separator characters. The "-" and "_" separators are treated as equivalent. All identifier field values are case-insensitive. Although case distinctions do not carry any special meaning, an implementation of LDML should use the casing recommendations in [BCP47], especially when a Unicode locale identifier is used for locale data exchange in software protocols. The recommendation is that: the region subtag is in uppercase, the script subtag is in title case, and all other subtags are in lowercase.
 
-See http://www.unicode.org/reports/tr35/tr35-47/tr35.html#Unicode_Language_and_Locale_Identifiers
+- See http://www.unicode.org/reports/tr35/tr35-47/tr35.html#Unicode_Language_and_Locale_Identifiers
+- See http://www.rfc-editor.org/rfc/bcp/bcp47.txt
 
-### SDKs
+As an example US english would be `"en-US"` instead of `EN_US`. 
 
-The SDKs should follow the changes as per mobile API but the `locale` properties should be of type [NSLocale](https://developer.apple.com/reference/foundation/nslocale) for iOS or [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android instead of String.
+### Core (communicating to an app)
 
-The Android SDK should create a locale object by using the static method `Locale.forLanguageTag`. The iOS SDK should create a locale object by using the `NSLocale` initializer `initWithLocaleIdentifier:`. 
+Core should continue to use `.language` parameters in addition to `.locale` parameters when sending RPCs to an app. If `.locale` is set to an identifier which matches an enum value of `Language` this enum value should be used for `.language`. Otherwise `.EN_US` should be used as a fallback to keep mandatory rules valid.
+
+Whenever Core receives an RPC from an app and `.locale` parameter is set Core should ignore `.language` parameter. This way Core should become 
+
+Core should continue to send `OnLanguageChange` notification followed by `OnLocaleChanged` notification to an app whenever the head unit language changes.
+
+### Proxies
+
+The proxies should follow the changes as per mobile API but the `locale` properties should not be of type String. Instead it should be: 
+- [NSLocale](https://developer.apple.com/reference/foundation/nslocale) for iOS. The iOS proxy should create a locale object by using the `NSLocale` initializer `initWithLocaleIdentifier:`.
+- [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android. The Android proxy should create a locale object by using the static method `Locale.forLanguageTag`.
+
+On head units that don't support locale the proxies should 
 
 Depending on the JSON data the SDK should use the `locale` parameter as the input for the Locale object by default. If the JSON data does not contain a `locale` parameter the SDK should use the `language` parameter instead to keep backward compatibility. If necessary the SDK should modify the `language` String to match the syntax of locale names ("EN_US" > "en-US").
 

--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -19,11 +19,11 @@ The proposed solution is to deprecate the `Language` enum. Instead the locale st
 
 ### Mobile API
 
-The enum `Language` should be deprecated with no replacement.
-The function `OnLanguageChange` should be deprecated and replaced by `OnLocaleChange`.
-Every `language` parameter should be deprecated and replaced by a `locale` parameter of type String.
-The parameter `languageDesired` should be deprecated and replaced by a `localeDesired` parameter of type String.
-Every `hmiDisplayLanguage` and `hmiDisplayLanguageDesired` parameter should be deprecated with no replacement.
+- The enum `Language` should be deprecated with no replacement.
+- The function `OnLanguageChange` should be deprecated and replaced by `OnLocaleChange`.
+- Every `language` parameter should be deprecated and replaced by a `locale` parameter of type String.
+- The parameter `languageDesired` should be deprecated and replaced by a `localeDesired` parameter of type String.
+- Every `hmiDisplayLanguage` and `hmiDisplayLanguageDesired` parameter should be deprecated with no replacement.
 
 ```xml
 <enum name="FunctionID">
@@ -78,31 +78,30 @@ Every `hmiDisplayLanguage` and `hmiDisplayLanguageDesired` parameter should be d
 
 ### HMI API
 
-The enum `Language` should be deprecated with no replacement.
-The function `OnLanguageChange` should be deprecated and replaced by `OnLocaleChange`.
-The function `GetSupportedLanguages` should be deprecated and replaced by `GetSupportedLocales`.
-The function `GetLanguage` should be deprecated and replaced by `GetLocale`.
-
-Every `language` parameter should be deprecated and replaced by a `locale` parameter of type String.
-The parameter `hmiDisplayLanguageDesired` should be deprecated and replaced by a `localeDesired` parameter of type String.
+- The enum `Language` should be removed with no replacement.
+- The function `OnLanguageChange` should be removed and replaced by `OnLocaleChange`.
+- The function `GetSupportedLanguages` should be removed and replaced by `GetSupportedLocales`.
+- The function `GetLanguage` should be removed and replaced by `GetLocale`.
+- Every `language` parameter should be removed and replaced by a `locale` parameter of type String.
+- The parameter `hmiDisplayLanguageDesired` should be removed and replaced by a `localeDesired` parameter of type String.
 
 #### Interface "Common"
 
 ```xml
-<enum name="Language"> <!-- DEPRECATED -->
+<enum name="Language"> <!-- REMOVE -->
   :
 </enum>
 :
 <struct name="HMIApplication">
   :
-  <param name="hmiDisplayLanguageDesired" type="Common.Language" mandatory="false"> <!-- DEPRECATED -->
+  <param name="hmiDisplayLanguageDesired" type="Common.Language" mandatory="false"> <!-- REMOVE -->
   <param name="localeDesired" type="String" mandatory="false" /> <!-- NEW -->
   :
 </struct>
 
 <struct name="KeyboardProperties">
   :
-  <param name="language" type="Common.Language" mandatory="false"> <!-- DEPRECATED -->
+  <param name="language" type="Common.Language" mandatory="false"> <!-- REMOVE -->
   <param name="locale" type="String" mandatory="false" /> <!-- NEW -->
   :
 </struct>
@@ -113,14 +112,14 @@ The parameter `hmiDisplayLanguageDesired` should be deprecated and replaced by a
 ```xml
 <function name="GetSystemInfo" messagetype="response">
   :
-  <param name="language" type="Common.Language" mandatory="true"> <!-- DEPRECATED -->
+  <param name="language" type="Common.Language" mandatory="true"> <!-- REMOVE -->
   <param name="locale" type="String" mandatory="true" /> <!-- NEW -->
   :
 </function>
 :
 <function name="OnSystemInfoChanged" messagetype="notification">
   :
-  <param name="language" type="Common.Language" mandatory="true"/> <!-- DEPRECATED -->
+  <param name="language" type="Common.Language" mandatory="true"/> <!-- REMOVE -->
   <param name="locale" type="String" mandatory="true" /> <!-- NEW -->
   :
 </function>
@@ -131,20 +130,20 @@ The parameter `hmiDisplayLanguageDesired` should be deprecated and replaced by a
 ```xml
 <function name="ChangeRegistration" messagetype="request">
   :
-  <param name="language" type="Common.Language" mandatory="true"> <!-- DEPRECATED -->
+  <param name="language" type="Common.Language" mandatory="true"> <!-- REMOVE -->
   <param name="locale" type="String" mandatory="true" /> <!-- NEW -->
   :
 </function>
 :
-<function name="OnLanguageChange" messagetype="notification"> <!-- DEPRECATED -->
+<function name="OnLanguageChange" messagetype="notification"> <!-- REMOVE -->
 :
 <function name="OnLocaleChange" messagetype="notification"> <!-- NEW -->
   <param name="locale" type="String" mandatory="true" />
 </function>
 :
-<function name="GetSupportedLanguages" messagetype="request"> <!-- DEPRECATED -->
+<function name="GetSupportedLanguages" messagetype="request"> <!-- REMOVE -->
 :
-<function name="GetSupportedLanguages" messagetype="response"> <!-- DEPRECATED -->
+<function name="GetSupportedLanguages" messagetype="response"> <!-- REMOVE -->
 :
 <function name="GetSupportedLocales" messagetype="request"> <!-- NEW -->
   <description>Request from SDL at system start-up. Response must provide the information about (VR|TTS|UI) supported languages.</description>
@@ -156,9 +155,9 @@ The parameter `hmiDisplayLanguageDesired` should be deprecated and replaced by a
   :
 </function>
 :
-<function name="GetLanguage" messagetype="request"> <!-- DEPRECATED -->
+<function name="GetLanguage" messagetype="request"> <!-- REMOVE -->
 :
-<function name="GetLanguage" messagetype="response"> <!-- DEPRECATED -->
+<function name="GetLanguage" messagetype="response"> <!-- REMOVE -->
 :
 <function name="GetLocale" messagetype="request"> <!-- NEW -->
   <description>Request from SDL to HMI to get the currently active (VR|TTS|UI) language.</description>
@@ -173,15 +172,25 @@ The parameter `hmiDisplayLanguageDesired` should be deprecated and replaced by a
 ```xml
 <function name="GetUserFriendlyMessage" messagetype="request" scope="internal">
   :
-  <param name="language" type="Common.Language" mandatory="false"> <!-- DEPRECATED -->
+  <param name="language" type="Common.Language" mandatory="false"> <!-- REMOVE -->
   <param name="locale" type="String" mandatory="false /> <!-- NEW -->
   :
 </function>
 ```
 
-### Core & HMI 
+### Core
 
-Core and HMI should continue to set the deprecated parameters and respond to the deprecated functions. 
+Depending on the app registration Core should be using the old `language` parameters or the new `locale` parameters.
+
+Example (assuming Locale support is implemented in version 4.5 of the mobile API):
+- An app registers using `RegisterAppInterface` with 
+    - `.sdlMsgVersion` set to `4.5.0` and
+    - `.localeDesired` set to `en-US` and
+    - `.languageDesired` set to a matching `Language.EN_US`
+- Core expects the app is working with locale parameters 
+- Core replies using `.locale` parameter instead of `.language` parameter.
+- If the language 
+
 If the head unit is configured to a locale which is listed in the `Language` enum the deprecated parameters should be set to that enum value. Otherwise `EN_US` should be used as a fallback.
 
 The `locale` parameters should follow the syntax of locale names. 

--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -187,13 +187,16 @@ The `.locale` parameters should follow the syntax of locale names.
 - See http://www.unicode.org/reports/tr35/tr35-47/tr35.html#Unicode_Language_and_Locale_Identifiers
 - See http://www.rfc-editor.org/rfc/bcp/bcp47.txt
 
-As an example US english would be `"en-US"` instead of `EN_US`. 
+Examples:
 
-### Core (communicating to an app)
+- `"en"` for english language or `"en-US"`, `"en-GB"`, `"en-AU"`, `"en-IN"` etc.
+- `"zh-Hans"` or `"zh-Hant"` for Chinese in the simplified or traditional script.
+
+### Core
 
 Core should continue to use `.language` parameters in addition to `.locale` parameters when sending RPCs to an app. If `.locale` is set to an identifier which matches an enum value of `Language` this enum value should be used for `.language`. Otherwise `.EN_US` should be used as a fallback to keep mandatory rules valid.
 
-Whenever Core receives an RPC from an app and `.locale` parameter is set Core should ignore `.language` parameter. This way Core should become 
+Whenever Core receives an RPC from an app and `.locale` parameter is set Core should ignore `.language` parameter. This way Core should be made ready when deprecations are removed.
 
 Core should continue to send `OnLanguageChange` notification followed by `OnLocaleChanged` notification to an app whenever the head unit language changes.
 
@@ -203,18 +206,14 @@ The proxies should follow the changes as per mobile API but the `locale` propert
 - [NSLocale](https://developer.apple.com/reference/foundation/nslocale) for iOS. The iOS proxy should create a locale object by using the `NSLocale` initializer `initWithLocaleIdentifier:`.
 - [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android. The Android proxy should create a locale object by using the static method `Locale.forLanguageTag`.
 
-On head units that don't support locale the proxies should 
-
-Depending on the JSON data the SDK should use the `locale` parameter as the input for the Locale object by default. If the JSON data does not contain a `locale` parameter the SDK should use the `language` parameter instead to keep backward compatibility. If necessary the SDK should modify the `language` String to match the syntax of locale names ("EN_US" > "en-US").
-
 ## Potential downsides
 
-The language parameters are mandatory for existing SDL integrations (Ford SYNC1 & SYNC3 with AppLink). Therefore they should be deprecated but still available for a long period of time until a threshold of active head units with locale support is reached. This threshold should be quite high (>90%) and may require years to happen.
+
 
 ## Impact on existing code
 
-The impact on existing code is quite high for mobile apps. Every app uses language parameters at least to register on the head unit. 
+N/A
 
 ## Alternatives considered
 
-As an alternative a new struct called `Locale` could be added to be more independent to the native phone OS SDKs.
+N/A

--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -15,7 +15,7 @@ SDL is not flexible in adding new languages or countries. It requires changes to
 
 ## Proposed solution
 
-The proposed solution is to deprecate the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR. Using unicode would allow SDL adopters to be more flexible but still follow a standard to agree to language codes.
+The proposed solution is to deprecate the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR. Using unicode allows SDL adopters to be more flexible but still follow a standard to agree to language codes.
 
 ### Mobile API
 
@@ -206,14 +206,18 @@ The proxies should follow the changes as per mobile API but the `locale` propert
 - [NSLocale](https://developer.apple.com/reference/foundation/nslocale) for iOS. The iOS proxy should create a locale object by using the `NSLocale` initializer `initWithLocaleIdentifier:`.
 - [java.util.Locale](https://developer.android.com/reference/java/util/Locale.html) for Android. The Android proxy should create a locale object by using the static method `Locale.forLanguageTag`.
 
+Although `RegisterAppInterface.localeDesired` and `ChangeRegistration.locale` are marked as mandatory in the mobile API they must not be marked as nonnull in the library. Otherwise nullability would be violated when using apps on existing head units.
+
 ## Potential downsides
 
-
+Apps would need to manually check `.locale` and `.language` parameters. On existing head units apps would not receive a `.locale`.
 
 ## Impact on existing code
 
-N/A
+Whenever an app wants to register or change an existing registration it has to set both `.language` and `.locale` as both are mandatory. Otherwise apps won't register. An app would receive two notifications when Core notifies about a language change. Both downsides should not cause any issue to existing apps or head units. Existing head units and apps would just ignore the locale parameters in the JSON data.
+
+The proposal should not cause a breaking change and can be integrated in a minor version increase.
 
 ## Alternatives considered
 
-N/A
+Deprecating `OnLanguageChange` on the mobile API is not key to this proposal. This proposal marks the RPC as deprecated only for naming reasons. 

--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -17,19 +17,18 @@ SDL is not flexible in adding new languages or countries. It requires changes to
 
 The proposed solution is to deprecate the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR. Using unicode would allow SDL adopters to be more flexible but still follow a standard to agree to language codes.
 
-### Mobile and HMI API
+### Mobile API
 
-- The `Language` enum should be deprecated with no replacement.
-- On the HMI side `GetLanguage` functions should be deprecated and replaced by `GetLocale` functions.
-
-Every existing parameter of type `Language` should be deprecated. As a replacement to the affected parameters new string parameters called `locale` (and `localeDesired`) should be added. The legacy parameter `hmiDisplayLanguage` and `hmiDisplayLanguageDesired` should not be replaced. 
-
-#### Mobile API
+The enum `Language` should be deprecated with no replacement.
+The function `OnLanguageChange` should be deprecated and replaced by `OnLocaleChange`.
+Every `language` parameter should be deprecated and replaced by a `locale` parameter of type String.
+The parameter `languageDesired` should be deprecated and replaced by a `localeDesired` parameter of type String.
+Every `hmiDisplayLanguage` and `hmiDisplayLanguageDesired` parameter should be deprecated with no replacement.
 
 ```xml
 <enum name="FunctionID">
   :
-  <element name="OnLocaleChangeID" value="..." hexvalue="..." /> <!-- NEW. Choosing value is not part of the proposal -->
+  <element name="OnLocaleChangeID" value="..." hexvalue="..." /> <!-- NEW -->
 </enum>
 :
 <enum name="Language"> <!-- DEPRECATED -->
@@ -77,7 +76,15 @@ Every existing parameter of type `Language` should be deprecated. As a replaceme
 </function>
 ```
 
-#### HMI API
+### HMI API
+
+The enum `Language` should be deprecated with no replacement.
+The function `OnLanguageChange` should be deprecated and replaced by `OnLocaleChange`.
+The function `GetSupportedLanguages` should be deprecated and replaced by `GetSupportedLocales`.
+The function `GetLanguage` should be deprecated and replaced by `GetLocale`.
+
+Every `language` parameter should be deprecated and replaced by a `locale` parameter of type String.
+The parameter `hmiDisplayLanguageDesired` should be deprecated and replaced by a `localeDesired` parameter of type String.
 
 #### Interface "Common"
 
@@ -166,14 +173,16 @@ Every existing parameter of type `Language` should be deprecated. As a replaceme
 ```xml
 <function name="GetUserFriendlyMessage" messagetype="request" scope="internal">
   :
-  <param name="language" type="Common.Language" mandatory="false">
+  <param name="language" type="Common.Language" mandatory="false"> <!-- DEPRECATED -->
+  <param name="locale" type="String" mandatory="false /> <!-- NEW -->
   :
 </function>
 ```
 
 ### Core & HMI 
 
-Core and HMI should continue to send the language parameters if the head unit is configured to a language which is listed in the `Language` enum. Otherwise they should use `EN_US` as a fallback.
+Core and HMI should continue to set the deprecated parameters and respond to the deprecated functions. 
+If the head unit is configured to a locale which is listed in the `Language` enum the deprecated parameters should be set to that enum value. Otherwise `EN_US` should be used as a fallback.
 
 The `locale` parameters should follow the syntax of locale names. 
 

--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -11,11 +11,18 @@ This proposal is about changing the way how SDL treats languages and localizatio
 
 ## Motivation
 
-SDL is not flexible in adding new languages or countries. It requires changes to the HMI and mobile API as well as SDL core. Furthermore it would be counterproductive to enumerate all possible variations of language and country SDL should support.
+SDL is not flexible in adding new languages or countries. It requires changes to the HMI and mobile API as well as SDL core. Furthermore it would be counterproductive to enumerate all possible variations of language and country SDL should support. One critical issue that was seen is that apps fail to register if it desires a language which is not known to the head unit.
+
+1. App registers with indian english as desired language
+2. Existing head units which don't know indian english in the Language enum will reply with INVALID_DATA
 
 ## Proposed solution
 
 The proposed solution is to deprecate the `Language` enum. Instead the locale structure provided by the native phone SDKs should be used that follows locale names defined by the unicode CLDR. Using unicode allows SDL adopters to be more flexible but still follow a standard to agree to language codes.
+
+1. App registers with indian english as desired locale
+2. Proxy internally sets the deprecated langauge parameter to something known (en_US)
+3. Any head unit (old and new) would successfuly register the app. The head units reply with the language (and locale for new head units) the head unit is configured to.
 
 ### Mobile API
 

--- a/proposals/0061-locale-support.md
+++ b/proposals/0061-locale-support.md
@@ -27,6 +27,11 @@ Every existing parameter of type `Language` should be deprecated. As a replaceme
 #### Mobile API
 
 ```xml
+<enum name="FunctionID">
+  :
+  <element name="OnLocaleChangeID" value="..." hexvalue="..." /> <!-- NEW. Choosing value is not part of the proposal -->
+</enum>
+:
 <enum name="Language"> <!-- DEPRECATED -->
   :
 </enum>
@@ -65,13 +70,10 @@ Every existing parameter of type `Language` should be deprecated. As a replaceme
   :
 </function>
 
-<function name="OnLanguageChange" functionID="OnLanguageChangeID" messagetype="notification">
+<function name="OnLanguageChange" functionID="OnLanguageChangeID" messagetype="notification"> <!-- DEPRECATED -->
   :
-  <param name="language" type="Language"> <!-- DEPRECATED -->
-  <param name="locale" type="String /> <!-- NEW -->
-  :
-  <param name="hmiDisplayLanguage" type="Language"> <!-- DEPRECATED -->
-  :
+<function name="OnLocaleChange" functionID="OnLocaleChangeID" messagetype="notification"> <!-- NEW -->
+  <param name="locale" type="String" /> <!-- NEW -->
 </function>
 ```
 
@@ -127,11 +129,10 @@ Every existing parameter of type `Language` should be deprecated. As a replaceme
   :
 </function>
 :
-<function name="OnLanguageChange" messagetype="notification">
-  :
-  <param name="language" type="Common.Language" mandatory="true"> <!-- DEPRECATED -->
-  <param name="locale" type="String" mandatory="true" /> <!-- NEW -->
-  :
+<function name="OnLanguageChange" messagetype="notification"> <!-- DEPRECATED -->
+:
+<function name="OnLocaleChange" messagetype="notification"> <!-- NEW -->
+  <param name="locale" type="String" mandatory="true" />
 </function>
 :
 <function name="GetSupportedLanguages" messagetype="request"> <!-- DEPRECATED -->


### PR DESCRIPTION
This proposal is about changing the way how SDL treats languages and localizations. The idea is to replace the `Language` enum and use the Locale structure/class of the native SDKs.

This PR updates the original proposal based on #179.