### PR TITLE
Updated 0078

### DIFF
--- a/proposals/0078-control_frame_payloads_v1_0_0.md
+++ b/proposals/0078-control_frame_payloads_v1_0_0.md
@@ -38,7 +38,7 @@ No defined payloads at this time.
 | Tag Name| Type | Description |
 |------------|------|-------------|
 |hashId|int32| Hash ID to identify this service and used when sending an `EndService` control frame|
-|MTU| int64 | Max transport unit to be used for this service|. If not included the client should use the protocol version default.|
+|mtu| int64 | Max transport unit to be used for this service|. If not included the client should use the protocol version default.|
 |protocolVersion|string| The negotiated version of the protocol. Must be in the format *"Major.Minor.Patch"*|
 
 
@@ -68,7 +68,7 @@ No defined payloads at this time.
 | Tag Name| Type | Description |
 |------------|------|-------------|
 |hashId|int32| Hash ID to identify this service and used when sending an `EndService` control frame|
-|MTU| int64 | Max transport unit to be used for this service. If not included the client should use the one set via the RPC service or protocol version default.|
+|mtu| int64 | Max transport unit to be used for this service. If not included the client should use the one set via the RPC service or protocol version default.|
 
 ###### Start Service NAK
 | Tag Name| Type | Description |
@@ -100,7 +100,7 @@ No defined payloads at this time.
 | Tag Name| Type | Description |
 |------------|------|-------------|
 |hashId|int32| Hash ID to identify this service and used when sending an `EndService` control frame|
-|MTU| int64 | Max transport unit to be used for this service. If not included the client should use the one set via the RPC service or protocol version default.|
+|mtu| int64 | Max transport unit to be used for this service. If not included the client should use the one set via the RPC service or protocol version default.|
 |height|int32| Accepted height in pixels from the client requesting the video service to start|
 |width|int32| Accepted width in pixels from the client requesting the video service to start|
 |videoProtocol|String| Accepted video protocol to be used. See `VideoStreamingProtocol ` RPC|
@@ -139,7 +139,7 @@ Since control frames will now have payloads we need to slightly modify how versi
 | Proxy| Direction | Core |
 |------------|------|-------------|
 |`StartService`<br> **Version:** v1 <br> **Payload:** Constructed payload [protocolVersion: 5.x.x]| ----------->| **v4 Core**: Ignores payload, sends protocol version 4 frame and uses previous negotiation scheme. <br> **v5 Core:** Reads in payload data, uses this information to determine version. 
-|| <-----------|`StartServiceACK`<br> **Version:** Highest version supported by both Core and Proxy<br> **Payload:** raw bytes for hashID
+|| <-----------|`StartServiceACK`<br> **Version:** Highest version supported by both Core and Proxy<br> **Payload:** Constructed payload [protocolVersion: 5.x.x, hashId: 0x9873, mtu: 130687]
 |`SingleFrame`<br> **Version:** Highest version supported by both Core and Proxy <br> **Payload:** Lots of bytes| ----------->|
 
 The proxy would include it's max supported version in the `StartService` payload, however, it would still operate under the same logic when receiving a `StartServiceACK` from Core to ensure proper version.  


### PR DESCRIPTION
Based on further investigations and the start of implementations, it was determined that the agreed upon revisions on SDL 0078 - Control Frame Payloads v1.0.0 (https://github.com/smartdevicelink/sdl_evolution/issues/222) will actually cause a breaking change.

The changing of the protocol header with the extension of 4 bytes will not work due to how version negotiation currently takes place. After the proxy sends a v1 `StartService` frame, the module sends back a `StartServiceACK` in a protocol header that matches its max protocol version. Older proxies will not know how to handle this for a few reasons:

- The iOS proxy currently doesn't implement a packet state machine that can churn through packets; it counts on the transport being reliable. Therefore, it would not see the packet as being valid, and throw it away.
- Current proxies expect a HashId to be included in the `StartServiceACK` as just raw bytes. If the proxies don't handle the extra 4 bytes in the header correctly it will assume the last 4 bytes of the header are part of the HashId.

Based on timing and it being a dependency of other Core 4.4.0 features, this can't wait until next week's meeting for discussion. With there being no real dissension on the original proposal, we believe it acceptable to move forward with minor revisions that leave us in a state with no breaking changes, but still provides an optimal solution.

The biggest changes from what was originally proposed:

- `controlVersion` is now `protocolVersion`. This is now the max supported protocol version from the proxy, and then the agreed upon version from Core in the `StartServiceACK`.
- Version negotiation is now altered. The initial `StartService` frame from the proxy will include its max protocol version. This lets Core determine the appropriate max version at that time and send a frame header the proxy will understand. For example, if the proxy sends a v1 packet with no payload the new v4.4.0 Core (that supports v5 of the protocol) will know it can't handle protocol v5, so it will instantly revert to v4 and thus not send a protocol header that may not be understood by the proxy.
- We have tested the addition of the payload in the initial `StartService` frame does not break either the Android or iOS proxy or the current Core software.
- The protocol header will retain having what will now be considered the `Major Version` of the protocol. The only use of minor and patch versions will be between the initial StartService and `StartServiceACK` for the RPC service.

Please review the changes on the pull request (https://github.com/smartdevicelink/sdl_evolution/pull/229). If there are any issues please let us know before the end of the week. Will be continuing work based on these revisions as to avoid missing contribution deadlines for features to be included in the Core 4.4 Release.