### PR TITLE
Add `hapticSpatialDataSupported` to `VideoStreamingCapability`

### DIFF
--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -114,6 +114,15 @@ This RPC would be the standardized SDL interface for haptic events, and would be
     </param>
 </function>
 
+<struct name="VideoStreamingCapability">
+	<description>Contains information about this system's video streaming capabilities.</description>
+	....
+	<param name="hapticSpatialDataSupported" type="Boolean" mandatory="false">
+      	<description>True if the system can utilize the haptic spatial data from the source being streamed. </description>
+	</param>
+    
+</struct>
+
 ```
 
 #### HMI_API
@@ -205,3 +214,7 @@ No new RPCs are added to support the plug-in interface. Rather, SystemRequest an
 
 #### Alternative #3:
 OEMs disclose their specific device specs to ISVs. This forces the ISVs to do custom work for each OEM.
+
+## Revisions
+- Alternative 1 was selected and proposal was rewritten to reflect it.
+- Added a new param `hapticSpatialDataSupported` to `VideoStreamingCapability`.


### PR DESCRIPTION
# Add hapticSpatialDataSupported to VideoStreamingCapability

* Altered Proposal: [SDL-0075](0075-HID-Support-Plug-in.md)
* Author: [Joey Grover](https://github.com/joeygrover)
* Status: **Awaiting Review**
* Impacted Platforms: [RPC/Android/iOS/Core]

## Introduction

With the acceptance of [0075 Human Interface Device Support](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md) we introduced a new feature that should be settable by the module that implements it.
 
## Motivation
There should be proper informing of whether or not the module supports the HID functionality. This will help reduce traffic if the system doesn't support it.

## Proposed solution
Add a single param to the `VideoStreamingCapability` struct:

```xml
    <struct name="VideoStreamingCapability">
        <description>Contains information about this system's video streaming capabilities.</description>
        ....
        <param name="hapticSpatialDataSupported" type="Boolean" mandatory="false">
            <description>True if the system can utilize the haptic spatial data from the source being streamed. </description>
        </param>
    
    </struct>

```

## Potential downsides
N/A


## Impact on existing code
- Shouldn't affect existing code as it is not implemented yet or been released. It will simply be the addition of another parameter to an existing struct.

## Alternatives considered
- Not introducing the param and letting the proxies send the HID data regardless.
