### PR TITLE
Change Parameter Types in 0075 HID Support Plug in

### DIFF
--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -74,16 +74,16 @@ This RPC would be the standardized SDL interface for haptic events, and would be
   <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
     <description>A user control spatial identifier</description>
   </param>
-  <param name="x" type="float" mandatory="true">
+  <param name="x" type="Integer" mandatory="true">
     <description>The X-coordinate of the user control</description>
   </param>
-  <param name="y" type="float" mandatory="true">
+  <param name="y" type="Integer" mandatory="true">
     <description>The Y-coordinate of the user control</description>
   </param>
-  <param name="width" type="float" mandatory="true">
+  <param name="width" type="Integer" mandatory="true">
     <description>The width of the user control's bounding rectangle</description>
   </param>
-  <param name="height" type="float" mandatory="true">
+  <param name="height" type="Integer" mandatory="true">
     <description>The height of the user control's bounding rectangle</description>
   </param>
 </struct>
@@ -136,16 +136,16 @@ This RPC would be the standardized SDL interface for haptic events, and would be
     <description>A user control's identifier.
     </description>
   </param>
-  <param name="x" type="float" mandatory="true">
+  <param name="x" type="Integer" mandatory="true">
     <description>The X-coordinate of the user control</description>
   </param>
-  <param name="y" type="float" mandatory="true">
+  <param name="y" type="Integer" mandatory="true">
     <description>The Y-coordinate of the user control</description>
   </param>
-  <param name="width" type="float" mandatory="true">
+  <param name="width" type="Integer" mandatory="true">
     <description>The width of the user control's bounding rectangle</description>
   </param>
-  <param name="height" type="float" mandatory="true">
+  <param name="height" type="Integer" mandatory="true">
     <description>The height of the user control's bounding rectangle</description>
   </param>
 </struct>


### PR DESCRIPTION
# Change data types in 0075 HID Support Plug in
* Altered Proposal [SDL-0075](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md)
* Author: [Brett McIsaac](https://github.com/brettywhite)
* Status: **Awaiting review**
* Impacted Platforms: [Core / iOS / Android / RPC]

## Introduction

With the acceptance of [SDL-0075](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md) we need to change the types of the parameters within the `SpatialStruct` class.

## Motivation

Floats don't make sense in this context of this struct, and it will maintain consistency.

## Proposed solution

In `SpatialStruct` change all parameters of type float to Integers.

## Potential downsides

N/A

## Impact on existing code

* None, as this code has not been implemented or released. It would simply modify the types in the struct as proposed originally.

## Alternatives considered

* None
