### PR TITLE
Change `HapticSpatialData` parameter name to `hapticSpatialData`

### DIFF
--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -93,7 +93,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
     Send the spatial data gathered from SDLCarWindow or VirtualDisplayEncoder to the HMI. 
     This data will be utilized by the HMI to determine how and when haptic events should occur
   </description>
-    <param name="HapticSpatialData" type="SpatialStruct" minsize="0" maxsize="1000" mandatory="false", array="true">
+    <param name="hapticSpatialData" type="SpatialStruct" minsize="0" maxsize="1000" mandatory="false", array="true">
       <description>
         Array of spatial data structures that represent the locations of all user controls present on the HMI. 
         This data should be updated if/when the application presents a new screen.
@@ -160,7 +160,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
     <param name="appID" type="Integer" mandatory="true">
       <description>Id of application related to this RPC.</description>
     </param>
-    <param name="HapticSpatialData" type="Common.SpatialStruct" minsize="0" maxsize="1000" mandatory="false", array="true">
+    <param name="hapticSpatialData" type="Common.SpatialStruct" minsize="0" maxsize="1000" mandatory="false", array="true">
       <description>
         Array of spatial data structures that represent the locations of all user controls present on the HMI. 
         This data should be updated if/when the application presents a new screen.
@@ -218,3 +218,4 @@ OEMs disclose their specific device specs to ISVs. This forces the ISVs to do cu
 ## Revisions
 - Alternative 1 was selected and proposal was rewritten to reflect it.
 - Added a new param `hapticSpatialDataSupported` to `VideoStreamingCapability`.
+- Changed `HapticSpatialData` parameter name to `hapticSpatialData`


### PR DESCRIPTION
# Change HapticSpatialData parameter name to hapticSpatialData
* Altered Proposal [SDL-0075](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md)
* Author: [Jacob Keeler](https://github.com/jacobkeeler)
* Status: **Awaiting review**
* Impacted Platforms: [Core / iOS / Android / RPC]

## Introduction

With the acceptance of [SDL-0075](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md) we need to change the name of the `HapticSpatialData` parameter to camel case.

## Motivation

Every parameter name in the spec uses camel case, `HapticSpatialData` needs to be changed to maintain consistency

## Proposed solution

Change the name of the `HapticSpatialData` parameter to `hapticSpatialData`

## Potential downsides

N/A

## Impact on existing code

* None, as this code has not yet been implemented or released. It would simply modify the name of this parameter in comparison to the original proposal.

## Alternatives considered

* None

