### PR TITLE
Change name of `SpatialStruct` to `Rect`

### DIFF
--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -69,7 +69,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 
 ```xml
 
-<struct name="SpatialStruct">
+<struct name="Rect">
   <description>Defines spatial for each user control object for video streaming application</description>
   <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
     <description>A user control spatial identifier</description>
@@ -132,7 +132,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 <interface name="Common" version="x.x.x" date="yyyy-mm-dd">
 
 <struct name="Rect">
-  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
+  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
     <description>A user control's identifier.
     </description>
   </param>

--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -131,7 +131,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 
 <interface name="Common" version="x.x.x" date="yyyy-mm-dd">
 
-<struct name="SpatialStruct">
+<struct name="Rect">
   <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
     <description>A user control's identifier.
     </description>

--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -71,7 +71,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 
 <struct name="SpatialStruct">
   <description>Defines spatial for each user control object for video streaming application</description>
-  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
+  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
     <description>A user control spatial identifier</description>
   </param>
   <param name="x" type="float" mandatory="true">

--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -70,20 +70,20 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 ```xml
 <struct name="Rectangle">
   <param name="x" type="float" mandatory="true">
-    <description>The X-coordinate of the user control</description>
+    <description>The upper left X-coordinate of the rectangle</description>
   </param>
   <param name="y" type="float" mandatory="true">
-    <description>The Y-coordinate of the user control</description>
+    <description>The upper left Y-coordinate of the rectangle</description>
   </param>
   <param name="width" type="float" mandatory="true">
-    <description>The width of the user control's bounding rectangle</description>
+    <description>The width of the rectangle</description>
   </param>
   <param name="height" type="float" mandatory="true">
-    <description>The height of the user control's bounding rectangle</description>
+    <description>The height of the rectangle</description>
   </param>
 </struct>
 
-<struct name="HapticData">
+<struct name="HapticRect">
   <description>Defines haptic data for each user control object for video streaming application</description>
   <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
     <description>A user control spatial identifier</description>
@@ -98,7 +98,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
     Send the spatial data gathered from SDLCarWindow or VirtualDisplayEncoder to the HMI. 
     This data will be utilized by the HMI to determine how and when haptic events should occur
   </description>
-    <param name="HapticSpatialData" type="SpatialStruct" minsize="0" maxsize="1000" mandatory="false", array="true">
+    <param name="hapticRectData" type="HapticRect" minsize="0" maxsize="1000" mandatory="false", array="true">
       <description>
         Array of spatial data structures that represent the locations of all user controls present on the HMI. 
         This data should be updated if/when the application presents a new screen.
@@ -151,7 +151,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
   </param>
 </struct>
 
-<struct name="HapticData">
+<struct name="HapticRect">
   <description>Defines haptic rectangle data for each user control object for video streaming application</description>
   <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
     <description>A user control spatial identifier</description>
@@ -171,7 +171,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
     <param name="appID" type="Integer" mandatory="true">
       <description>Id of application related to this RPC.</description>
     </param>
-    <param name="HapticSpatialData" type="Common.SpatialStruct" minsize="0" maxsize="1000" mandatory="false", array="true">
+    <param name="hapticRectData" type="Common.HapticRect" minsize="0" maxsize="1000" mandatory="false", array="true">
       <description>
         Array of spatial data structures that represent the locations of all user controls present on the HMI. 
         This data should be updated if/when the application presents a new screen.

--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -84,7 +84,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 </struct>
 
 <struct name="HapticData">
-  <description>Defines spatial for each user control object for video streaming application</description>
+  <description>Defines haptic data for each user control object for video streaming application</description>
   <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
     <description>A user control spatial identifier</description>
   </param>
@@ -136,11 +136,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 
 <interface name="Common" version="x.x.x" date="yyyy-mm-dd">
 
-<struct name="Rect">
-  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
-    <description>A user control's identifier.
-    </description>
-  </param>
+<struct name="Rectangle">
   <param name="x" type="float" mandatory="true">
     <description>The X-coordinate of the user control</description>
   </param>
@@ -152,6 +148,16 @@ This RPC would be the standardized SDL interface for haptic events, and would be
   </param>
   <param name="height" type="float" mandatory="true">
     <description>The height of the user control's bounding rectangle</description>
+  </param>
+</struct>
+
+<struct name="HapticData">
+  <description>Defines haptic rectangle data for each user control object for video streaming application</description>
+  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
+    <description>A user control spatial identifier</description>
+  </param>
+  <param name="rect" type="Common.Rectangle" mandatory="true">
+    <description>The position of the haptic rectangle to be highlighted. The center of this rectangle will be "touched" when a press occurs.</description>
   </param>
 </struct>
 

--- a/proposals/0075-HID-Support-Plug-in.md
+++ b/proposals/0075-HID-Support-Plug-in.md
@@ -68,12 +68,7 @@ This RPC would be the standardized SDL interface for haptic events, and would be
 #### Mobile_API
 
 ```xml
-
-<struct name="Rect">
-  <description>Defines spatial for each user control object for video streaming application</description>
-  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="false">
-    <description>A user control spatial identifier</description>
-  </param>
+<struct name="Rectangle">
   <param name="x" type="float" mandatory="true">
     <description>The X-coordinate of the user control</description>
   </param>
@@ -85,6 +80,16 @@ This RPC would be the standardized SDL interface for haptic events, and would be
   </param>
   <param name="height" type="float" mandatory="true">
     <description>The height of the user control's bounding rectangle</description>
+  </param>
+</struct>
+
+<struct name="HapticData">
+  <description>Defines spatial for each user control object for video streaming application</description>
+  <param name="id" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
+    <description>A user control spatial identifier</description>
+  </param>
+  <param name="rect" type="Rectangle" mandatory="true">
+    <description>The position of the haptic rectangle to be highlighted. The center of this rectangle will be "touched" when a press occurs.</description>
   </param>
 </struct>
 


### PR DESCRIPTION
# Change HapticSpatialData parameter name to hapticSpatialData
* Altered Proposal [SDL-0075](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md)
* Author: [Joel Fischer](https://github.com/joeljfischer)
* Status: **Awaiting review**
* Impacted Platforms: [Core / iOS / Android / RPC]

## Introduction

With the acceptance of [SDL-0075](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0075-HID-Support-Plug-in.md) we should change the name of the `SpatialStruct` struct to `Rect`.

## Motivation

We don't typically describe structs with `Struct` in the actual name, but `Spatial` doesn't work alone. Since this is simply a typical rect, with the addition of an optional `id`, we should keep it for general purpose rect usage.

## Proposed solution

Change the name of the `SpatialStruct` to `Rect`

## Potential downsides

N/A

## Impact on existing code

* None, as this code has not yet been implemented or released. It would simply modify the name of this parameter in comparison to the original proposal.

## Alternatives considered

* None
