### PR TITLE
Change TextFieldType to MetadataType in HMI_API

### DIFF
--- a/proposals/0073-Adding-Metadata-Types.md
+++ b/proposals/0073-Adding-Metadata-Types.md
@@ -27,12 +27,12 @@ For each text field in the HMI API, a new optional parameter "fieldType" can be 
   <param name="fieldText" type="String" maxlength="500" mandatory="true">
     <description>The  text itself.</description>
   </param>
-  <param name="fieldType" type="Common.TextFieldType" minsize="0" maxsize="5" array="true" mandatory="false">
+  <param name="fieldType" type="Common.MetadataType" minsize="0" maxsize="5" array="true" mandatory="false">
     <description>The type of data contained in the field.</description>
   </param>
 </struct>
 
-<enum name="TextFieldType">
+<enum name="MetadataType">
   <element name="mediaTitle">
     <description>The data in this field contains the title of the currently playing audio track.</description>
   </element>


### PR DESCRIPTION
# Change TextFieldType to MetadataType in HMI_API
* Altered Proposal [SDL-0073 Adding Metadata Types](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0073-Adding-Metadata-Types.md)
* Author: [Jacob Keeler](https://github.com/jacobkeeler)
* Status: **Awaiting review**
* Impacted Platforms: [Core / RPC]

## Introduction

With the acceptance of [SDL-0073 Adding Metadata Types](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0073-Adding-Metadata-Types.md) and revision #239, any relevant struct/enum names need to be changed accordingly in the HMI API.

## Motivation

With the change from `TextFieldType` to `MetadataType` in the Mobile API, the HMI API should be updated accordingly

## Proposed solution

Change the name of the `TextFieldType` enum to `MetadataType` in the HMI API

## Potential downsides

N/A

## Impact on existing code

* None, as this code has not yet been implemented or released. It would simply modify the name of this parameter in comparison to the original proposal.

## Alternatives considered

* None