### PR TITLE
Accepted SDL Remote Control Baseline proposal: modify Radio Enabled control item comment for clarity

### DIFF
--- a/proposals/0071-remote-control-baseline.md
+++ b/proposals/0071-remote-control-baseline.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0071](0071-remote-control-baseline.md)
 * Author: [Zhimin Yang](https://github.com/yang1070)
 * Status: **Accepted**
-* Impacted Platforms: [Core / iOS / Android / RPC ]
+* Impacted Platforms: [Core / iOS / Android / RPC]
 
 ## Introduction
 
@@ -40,7 +40,7 @@ The following table lists what control items are considered in the each control 
 
 | RC Module | Control Item | Value Range |Type | Comments |
 | ------------ | ------------ |------------ | ------------ | ------------ |
-| Radio | Radio Enabled | true,false  | Get/Set/Notification| read only, all other radio control items need radio enabled to work|
+| Radio | Radio Enabled | true,false  | Get/Set/Notification| when the radio is disabled, no data other than `radioEnable` is included in a `GetInteriorVehicleData` response|
 |       | Radio Band | AM,FM,XM  | Get/Set/Notification| |
 |       | Radio Frequency | | Get/Set/Notification | value range depends on band |
 |       | Radio RDS Data | | Get/Notification | read only |


### PR DESCRIPTION
# Accepted SDL Remote Control Baseline proposal: modify Radio Enabled control item comment for clarity

* Altered Proposal: [SDL-0071](0071-remote-control-baseline.md)
* Author: [Renata Fros](https://github.com/rfros-nextradio)
* Status: **Awaiting Review**
* Impacted Platforms: [Core / iOS / Android / RPC]

## Introduction

In reviewing the [RC baseline proposal](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0071-remote-control-baseline.md), we noticed the `Set` capability was added to the “Radio Enabled” control item (it is not present in the [original RC proposal](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0065-remote-control.md)). We were happy to see the addition, but confused by its comment:

> read only, all other radio control items need radio enabled to work

After a clarifying discussion with SDL engineers and the proposal's orginal author, we determined the wording for the item simply wasn't updated when `Set` was added.

Background and additional context for this request is contained in a thread found in the sdl_evolution channel on Slack. Conversation was between myself, Jacob Keeler, and Zhimin Yang: https://smartdevicelink.slack.com/archives/C1RR77UAX/p1505250378000059

## Motivation

Accurate documentation for developers looking to use RC baseline features in app development.

## Proposed solution

Quick rewording of comment from

> read only, all other radio control items need radio enabled to work

to 

> when the radio is disabled, no data other than `radioEnable` is included in a `GetInteriorVehicleData` response

## Potential downsides

N/A

## Impact on existing code

N/A

## Alternatives considered

N/A