### PR TITLE
Change ATF test reports folder structure

### DIFF
--- a/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
+++ b/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
@@ -9,10 +9,10 @@
 
 Main output of ATF is test reports.
 ATF provide such reports:
-* Console logs
-* SDL logs
-* Transport logs
-* Detailed report
+* Console logs - name of test cases with execution status FAILED/PASSED.
+* SDL logs - SDL log received by ATF via telnet logger.
+* Transport logs -  all received and sent data from/to SDL. Transport log can have default view - messages on protocol level (except binaries) and full view - log will be expanded with packages: streamings, service messages, heartbeat, json files.   
+* Detailed report - all expected and sent massages related to test cases with expected and actual result.Also contains info about test cases: name, time, sequence, status, duration.
 
 This proposal is about creating clear and useful structure of test scripts reports.
 

--- a/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
+++ b/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
@@ -1,0 +1,55 @@
+# Change ATF test reports folder structure
+
+* Proposal: [SDL-NNNN](NNNN-Change_ATF_test_reports_folder_structure.md)
+* Author: [Irina Getmanets](https://github.com/GetmanetsIrina)
+* Status: **Awaiting review**
+* Impacted Platforms: ATF
+
+## Introduction
+
+For now ATF reports folder has inconvenient nested structure. ATF creates structure of folders from relative path to script, e.g. runned script fom test_scripts/API/Navidation/Subscriptions/.
+With current implementation will be created the next structure
+<pre><code>
+TestingReports
+  ->ATF_timestamp
+    ->test_scripts
+      ->API
+      	->Navigation
+	  ->Subscriptions
+  ->SDL_timestamp
+    ->test_scripts
+      ->API
+      	->Navigation
+	  ->Subscriptions
+  ->Reports_timestamp
+    ->test_scripts
+      ->API
+      	->Navigation
+	  ->Subscriptions
+</pre></code>
+
+## Motivation
+
+Create more convenient reports structure, less nested.
+
+## Proposed solution
+
+The solution is to create new structure:
+<pre><code>TestingReports
+	-> ScriptName_timestamp
+		-> ATF
+		-> SDL</pre></code>
+Subfolder ATF will contain ATF logs and report.
+Subfolder SDL will contain SDL logs.
+
+## Potential downsides
+
+n/a
+
+## Impact on existing code
+
+Impact on ATF reporting functionality.
+
+## Alternatives considered
+
+n/a

--- a/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
+++ b/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
@@ -18,7 +18,7 @@ This proposal is about creating clear and useful structure of test scripts repor
 
 ## Motivation
 
-Create more convenient reports structure, less nested. Multiple running of test script should not override old reports. Structure of reports should be clear for easy searching certain report.
+Create more convenient reports structure, less nested. Running multiple test scripts should not override old reports. Structure of reports should be clear, so you can easily search for a certain report.
 
 ## Proposed solution
 

--- a/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
+++ b/proposals/NNNN-Change_ATF_test_reports_folder_structure.md
@@ -7,38 +7,28 @@
 
 ## Introduction
 
-For now ATF reports folder has inconvenient nested structure. ATF creates structure of folders from relative path to script, e.g. runned script fom test_scripts/API/Navidation/Subscriptions/.
-With current implementation will be created the next structure
-<pre><code>
-TestingReports
-  ->ATF_timestamp
-    ->test_scripts
-      ->API
-      	->Navigation
-	  ->Subscriptions
-  ->SDL_timestamp
-    ->test_scripts
-      ->API
-      	->Navigation
-	  ->Subscriptions
-  ->Reports_timestamp
-    ->test_scripts
-      ->API
-      	->Navigation
-	  ->Subscriptions
-</pre></code>
+Main output of ATF is test reports.
+ATF provide such reports:
+* Console logs
+* SDL logs
+* Transport logs
+* Detailed report
+
+This proposal is about creating clear and useful structure of test scripts reports.
 
 ## Motivation
 
-Create more convenient reports structure, less nested.
+Create more convenient reports structure, less nested. Multiple running of test script should not override old reports. Structure of reports should be clear for easy searching certain report.
 
 ## Proposed solution
 
 The solution is to create new structure:
-<pre><code>TestingReports
-	-> ScriptName_timestamp
+```
+TestingReports
+	-> ScriptName_YYYYMMDDHHMMSS
 		-> ATF
-		-> SDL</pre></code>
+		-> SDL 
+```
 Subfolder ATF will contain ATF logs and report.
 Subfolder SDL will contain SDL logs.
 
@@ -52,4 +42,4 @@ Impact on ATF reporting functionality.
 
 ## Alternatives considered
 
-n/a
+Leave as is.


### PR DESCRIPTION
Main output of ATF is test reports. ATF provide such reports:

- Console logs - name of test cases with execution status FAILED/PASSED.
- SDL logs - SDL log received by ATF via telnet logger.
- Transport logs - all received and sent data from/to SDL. Transport log can have default view - messages on protocol level (except binaries) and full view - log will be expanded with packages: streamings, service messages, heartbeat, json files.
- Detailed report - all expected and sent massages related to test cases with expected and actual result.Also contains info about test cases: name, time, sequence, status, duration.

This proposal is about creating clear and useful structure of test scripts reports.