### PR TITLE
Default SoftButtonCapabilities

### DIFF
--- a/nnnn-default-softbuttoncapabilities.md
+++ b/nnnn-default-softbuttoncapabilities.md
@@ -35,7 +35,7 @@ To resolve this shortcoming for any given template, the mobile libraries need to
 | NON_MEDIA                          | 8    |
 
 ## Potential downsides
-Complexity in the mobile libraries increases to recover from incorrect HMI side implementations, however in this case the changes are warranted.
+Complexity in the mobile libraries is being introduced to recover from incorrect HMI side implementations, however in this case the changes are warranted.
 
 ## Impact on existing code
 Introduce new / update existing methods in the mobile API to accommodate for default list size values per template.

--- a/nnnn-default-softbuttoncapabilities.md
+++ b/nnnn-default-softbuttoncapabilities.md
@@ -7,18 +7,20 @@
 
 ## Introduction
 
-This proposal is to update the iOS and Android proxy libraries with specified default SoftButtonCapabilities values from the RegisterAppInterface and SetDisplayLayout responses when the headunit erroneously returns a SoftButtonCapabilities list of size 1.
+This proposal is to update the iOS and Android mobile libraries with a specified default list size value for SoftButtonCapabilities when a headunit erroneously returns a SoftButtonCapabilities list that contains just one item.  A SoftButtonCapabilities list is received from the RegisterAppInterface and SetDisplayLayout RPC responses.  The purpose of the SoftButtonCapabilities list in these RPC's is to inform the mobile application how many SoftButtons are available for the utilized template and the capabilites of each SoftButton.
 
 ## Motivation
 
-An existing head unit implementation in the field 
+An existing OEM head unit implementation in the field always incorrectly returns a SoftButtonCapabilities list with just one item from both the RegisterAppInterface and SetDisplayLayout RPC responses.  Unfortunately this causes a problem for app developers as they have no way of knowing how many softbuttons are actually supported for a particular template being utilized by the app.  
 
 ## Proposed solution
+To resolve this shortcoming for any given template the mobile libraries need to be updated to return default list size values to the mobile application when an incorrect headunit implementation has been detected (SoftButtonCapabilities list value equals 1).
 
 ## Potential downsides
+Complexity in the mobile libraries increases to recover from incorrect HMI side implementations, however in this case the changes are warranted.
 
 ## Impact on existing code
-
+Introduce new / update existing methods in the mobile API to accommodate for default list size values per template.
 
 ## Alternatives considered
-
+None as the wrong HMI implementation already exists in the field.

--- a/nnnn-default-softbuttoncapabilities.md
+++ b/nnnn-default-softbuttoncapabilities.md
@@ -1,0 +1,24 @@
+# Default SoftButtonCapabilities
+
+* Proposal: [SDL-NNNN](nnnn-default-softbuttoncapabilities.md)
+* Author: [Markos Rapitis](https://github.com/mrapitis) 
+* Status: **Awaiting Review**
+* Impacted Platforms: [iOS, Android]
+
+## Introduction
+
+This proposal is to update the iOS and Android proxy libraries with specified default SoftButtonCapabilities values from the RegisterAppInterface and SetDisplayLayout responses when the headunit erroneously returns a SoftButtonCapabilities list of size 1.
+
+## Motivation
+
+An existing head unit implementation in the field 
+
+## Proposed solution
+
+## Potential downsides
+
+## Impact on existing code
+
+
+## Alternatives considered
+

--- a/nnnn-default-softbuttoncapabilities.md
+++ b/nnnn-default-softbuttoncapabilities.md
@@ -7,14 +7,32 @@
 
 ## Introduction
 
-This proposal is to update the iOS and Android mobile libraries with a specified default list size value for SoftButtonCapabilities when a headunit erroneously returns a SoftButtonCapabilities list that contains just one item.  A SoftButtonCapabilities list is received from the RegisterAppInterface and SetDisplayLayout RPC responses.  The purpose of the SoftButtonCapabilities list in these RPC's is to inform the mobile application how many SoftButtons are available for the utilized template and the capabilites of each SoftButton.
+This proposal is to update the iOS and Android mobile libraries with a specified default list size value for SoftButtonCapabilities when a headunit erroneously returns a SoftButtonCapabilities list that contains just one item.  The purpose of the SoftButtonCapabilities list is to inform the mobile application how many SoftButtons are available for the utilized template and the capabilites of each SoftButton. The  SoftButtonCapabilities list is received by the mobile application from the RegisterAppInterface and SetDisplayLayout RPC responses.
 
 ## Motivation
 
 An existing OEM head unit implementation in the field always incorrectly returns a SoftButtonCapabilities list with just one item from both the RegisterAppInterface and SetDisplayLayout RPC responses.  Unfortunately this causes a problem for app developers as they have no way of knowing how many softbuttons are actually supported for a particular template being utilized by the app.  
 
 ## Proposed solution
-To resolve this shortcoming for any given template the mobile libraries need to be updated to return default list size values to the mobile application when an incorrect headunit implementation has been detected (SoftButtonCapabilities list value equals 1).
+To resolve this shortcoming for any given template, the mobile libraries need to be updated to return default list size values to the mobile application when an incorrect headunit implementation has been detected (SoftButtonCapabilities list value count is one). The table below contains default SoftButtonCapabilities lists sizes for each supported template:
+
+| Template Name                      | SoftButton's Avail |
+| ---------------------------------- |:--------:|
+| MEDIA                              | 8    |
+| GRAPHIC_WITH_TEXT                  | 0    |
+| TEXT_WITH_GRAPHIC                  | 0    |
+| TILES_ONLY                         | 8    |
+| TEXTBUTTONS_ONLY                   | 8    |
+| GRAPHIC_WITH_TILES                 | 3    |
+| TILES_WITH_GRAPHIC                 | 3    |
+| GRAPHIC_WITH_TEXT_AND_SOFTBUTTONS  | 2    |
+| TEXT_AND_SOFTBUTTONS_WITH_GRAPHIC  | 2    |
+| GRAPHIC_WITH_TEXTBUTTONS           | 3    |
+| TEXTBUTTONS_WITH_GRAPHIC           | 3    |
+| LARGE_GRAPHIC_WITH_SOFTBUTTONS     | 8    |
+| DOUBLE_GRAPHIC_WITH_SOFTBUTTONS    | 8    |
+| LARGE_GRAPHIC_ONLY                 | 0    |
+| NON_MEDIA                          | 8    |
 
 ## Potential downsides
 Complexity in the mobile libraries increases to recover from incorrect HMI side implementations, however in this case the changes are warranted.

--- a/nnnn-default-softbuttoncapabilities.md
+++ b/nnnn-default-softbuttoncapabilities.md
@@ -21,7 +21,7 @@ To resolve this shortcoming for any given template, the mobile libraries need to
 | MEDIA                              | 8    |
 | GRAPHIC_WITH_TEXT                  | 0    |
 | TEXT_WITH_GRAPHIC                  | 0    |
-| TILES_ONLY                         | 8    |
+| TILES_ONLY                         | 7    |
 | TEXTBUTTONS_ONLY                   | 8    |
 | GRAPHIC_WITH_TILES                 | 3    |
 | TILES_WITH_GRAPHIC                 | 3    |
@@ -41,4 +41,4 @@ Complexity in the mobile libraries is being introduced to recover from incorrect
 Introduce new / update existing methods in the mobile API to accommodate for default list size values per template.
 
 ## Alternatives considered
-None as the wrong HMI implementation already exists in the field.
+Setting a fixed number of SoftButtons per template was also considered in our SoftButtonCapabilities workshop.

--- a/nnnn-default-softbuttoncapabilities.md
+++ b/nnnn-default-softbuttoncapabilities.md
@@ -2,12 +2,12 @@
 
 * Proposal: [SDL-NNNN](nnnn-default-softbuttoncapabilities.md)
 * Author: [Markos Rapitis](https://github.com/mrapitis) 
-* Status: **Awaiting Review**
+* Status: **Awaiting review**
 * Impacted Platforms: [iOS, Android]
 
 ## Introduction
 
-This proposal is to update the iOS and Android mobile libraries with a specified default list size value for SoftButtonCapabilities when a headunit erroneously returns a SoftButtonCapabilities list that contains just one item.  The purpose of the SoftButtonCapabilities list is to inform the mobile application how many SoftButtons are available for the utilized template and the capabilites of each SoftButton. The  SoftButtonCapabilities list is received by the mobile application from the RegisterAppInterface and SetDisplayLayout RPC responses.
+This proposal is to update the iOS and Android mobile libraries with a specified default list size value for SoftButtonCapabilities when a headunit erroneously returns a SoftButtonCapabilities list that contains just one item.  The purpose of the SoftButtonCapabilities list is to inform the mobile application how many SoftButtons are available for the utilized template and the capabilities of each SoftButton. The  SoftButtonCapabilities list is received by the mobile application from the RegisterAppInterface and SetDisplayLayout RPC responses.
 
 ## Motivation
 


### PR DESCRIPTION
This proposal is to update the iOS and Android mobile libraries with a specified default list size value for SoftButtonCapabilities when a headunit erroneously returns a SoftButtonCapabilities list that contains just one item. The purpose of the SoftButtonCapabilities list is to inform the mobile application how many SoftButtons are available for the utilized template and the capabilites of each SoftButton. The SoftButtonCapabilities list is received by the mobile application from the RegisterAppInterface and SetDisplayLayout RPC responses.