### PR TITLE
Configurable time before shutdown

### DIFF
--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -27,8 +27,8 @@ RegisterApplication()
 ActivateApplication
 PutFile(some_big_file)
 StopSDL()
-
 ```
+
 After run of this script with bit probability Logs of Put file request wind be written to SDL. 
 To avoid such behaviour script should be modified :
 ```
@@ -38,24 +38,38 @@ ActivateApplication
 PutFile(some_big_file)
 Sleep(SomeMagicTime)
 StopSDL()
-
 ```
+
 But SomeMagicTime will be different for different workstations and depend from operation system load.
 So this problem can be solved only with modifications on SDL side. 
 
 ## Proposed solution
 
-Add option to flush log messages before shutdown. 
-Add option with time that  
+ - Add option to flush log messages before shutdown.
+ - Add option that specifies time maximum before shutdown.
+
+```
+// Write all logs un queue to filesystem before shutdown 
+FushLogMessagesBeforeShutdown = false
+
+// Maximum time to wait for writing all data before exit sdl in seconds
+MaxTimeBeforeShutdown = 30
+```
+
+By default `FushLogMessagesBeforeShutdown` should be false. In that case SDL should not wait for writing all data to file system ans stop process after receiving `OnExitAllApplications` notification. 
+
+`MaxTimeBeforeShutdown` doe used in case if `FushLogMessagesBeforeShutdown` is `true`. It should measure timer from `OnExitAllApplications` notification received. In case if writing logs to file system takes moer than specified, SDL should terminate writing and finish process. 
+
 
 ## Potential downsides
 
-Describe any potential downsides or known objections to the course of action presented in this proposal, then provide counter-arguments to these objections. You should anticipate possible objections that may come up in review and provide an initial response here. Explain why the positives of the proposal outweigh the downsides, or why the downside under discussion is not a large enough issue to prevent the proposal from being accepted.
+N/A
 
 ## Impact on existing code
 
-Describe the impact that this change will have on existing code. Will some SDL integrations stop compiling due to this change? Will applications still compile but produce different behavior than they used to? Is it possible to migrate existing SDL code to use a new feature or API automatically?
+Impact ignition off process of SDL core.
 
 ## Alternatives considered
-
-Describe alternative approaches to addressing the same problem, and why you chose this approach instead.
+ 1. Do not write all logs to SDL before shutdown ( some logs may  be missed)
+ 2. Write all logs before shutdown ( shutdown may take a log time)
+ 

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -13,7 +13,7 @@ To prevent missing logs after SDL shutdown, additional ini file options should b
  
 ## Motivation
 
-In some use cases (like video streaming or big put file) SDL can procude tone (up to gigabyte) of logs in asynchronous mode. 
+In some use cases (like video streaming or big put file) SDL can produce a ton (up to 1 gigabyte) of logs in asynchronous mode. 
 SDL collects these logs in queue and and writes them to a file system in a separate thread.
 Writing to the file system may require big amount of time (sometimes up to 5 - 10 minutes).
 

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -14,11 +14,12 @@ To prevent missing logs after SDL shutdown, additional ini file options should b
 ## Motivation
 
 SDL produces a tone of logs in the asynchronous mode in some use cases (like video streaming or big put file),
-SDL collects these logs in queue and write them to file system in a separate thread.
-Writing to the file system may require big amount of time.
+In som use cases (like video streaming or big put file) SDL can procude tone (up to gigabyte) of logs in asynchronous mode. 
+SDL collects these logs in queue and and writes them to a file system in a separate thread.
+Writing to the file system may require big amount of time (sometimes up to 5 - 10 minutes).
 
-In current implementation after receiving IGNITION_OFF signal SDL drops all logs that was not written yet.
-Such behavior sometimes prevents analyzing of SDL issues that found by ATF script, and requires adding extra timeouts in test scripts before SDL shutdown.
+In the current implementation, after receiving IGNITION_OFF signal, SDL drops all logs that have not yet been written.
+Such behavior sometimes prevents analyzing of SDL issues that are found by the ATF script, and requires adding extra timeouts in test scripts before SDL shutdown.
 
 This is an example of sequence in script:
 
@@ -57,7 +58,7 @@ FlushLogMessagesBeforeShutdown = false
 MaxTimeBeforeShutdown = 30
 ```
 
-By default `FlushLogMessagesBeforeShutdown` should be false. In that case SDL should not wait for writing all data to file system ans stop process after receiving `OnExitAllApplications` notification. 
+By default `FlushLogMessagesBeforeShutdown` should be false. In that case, SDL should not wait for all data to be written to the file system and stop process after receiving `OnExitAllApplications` notification. 
 
 `MaxTimeBeforeShutdown` would be used in case if `FlushLogMessagesBeforeShutdown` is `true`. It should measure time from `OnExitAllApplications` notification received. In case if writing logs to file system takes more time than specified, SDL should terminate writing and finish process. 
 

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -13,8 +13,7 @@ To prevent missing logs after SDL shutdown, additional ini file options should b
  
 ## Motivation
 
-SDL produces a tone of logs in the asynchronous mode in some use cases (like video streaming or big put file),
-In som use cases (like video streaming or big put file) SDL can procude tone (up to gigabyte) of logs in asynchronous mode. 
+In some use cases (like video streaming or big put file) SDL can procude tone (up to gigabyte) of logs in asynchronous mode. 
 SDL collects these logs in queue and and writes them to a file system in a separate thread.
 Writing to the file system may require big amount of time (sometimes up to 5 - 10 minutes).
 

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -1,0 +1,61 @@
+# Configurable time before shutdown
+
+* Proposal: [SDL-NNNN](nnnn-configurable-time-before-shutdown.md)
+* Author: [Alexander Kutsan](https://github.com/LuxoftAKutsan)
+* Status: **Awaiting review**
+* Impacted Platforms: [Core]
+
+## Introduction
+
+This proposal is about adding new parameters in ini file for configureing time to stopping SDL process after receiving Ignition off signal.
+And configuring option if SDL should write all logs to the file system before shudown. 
+
+## Motivation
+
+In debug mode SDL produce a lot of logs.
+Logging is asyncronious not to reduce eficiency of SDL business loginc. 
+In some use cases (like videostreaming orbit Put file) SDL produce more logs than it can write to file system. 
+SDL collect this logs in queue and write to file system in separate thread. 
+After receiving IGNITION_OFF signal currently SDL drop all logs that was not written yet.
+Such behaviour prevents analysing of SDL issues that found by ATF script by SDL logs, and requires adding additional timouts in test scripts before SDL shutdown.
+
+This is example of sequence in script:
+
+```
+StartSDL()
+RegisterApplication()
+ActivateApplication
+PutFile(some_big_file)
+StopSDL()
+
+```
+After run of this script with bit probability Logs of Put file request wind be written to SDL. 
+To avoid such behaviour script should be modified :
+```
+StartSDL()
+RegisterApplication()
+ActivateApplication
+PutFile(some_big_file)
+Sleep(SomeMagicTime)
+StopSDL()
+
+```
+But SomeMagicTime will be different for different workstations and depend from operation system load.
+So this problem can be solved only with modifications on SDL side. 
+
+## Proposed solution
+
+Add option to flush log messages before shutdown. 
+Add option with time that  
+
+## Potential downsides
+
+Describe any potential downsides or known objections to the course of action presented in this proposal, then provide counter-arguments to these objections. You should anticipate possible objections that may come up in review and provide an initial response here. Explain why the positives of the proposal outweigh the downsides, or why the downside under discussion is not a large enough issue to prevent the proposal from being accepted.
+
+## Impact on existing code
+
+Describe the impact that this change will have on existing code. Will some SDL integrations stop compiling due to this change? Will applications still compile but produce different behavior than they used to? Is it possible to migrate existing SDL code to use a new feature or API automatically?
+
+## Alternatives considered
+
+Describe alternative approaches to addressing the same problem, and why you chose this approach instead.

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -7,17 +7,19 @@
 
 ## Introduction
 
-This proposal is about adding new parameters in ini file for configuration time to stopping SDL process after receiving Ignition off signal.
-And configuring option if SDL should write all logs to the file system before shutdown. 
-
+To prevent missing logs in SDL shutdown add Additional ini file options:
+ - Write all logs to file system before shutdown 
+ - Maximum time of sdl shutting down
+ 
 ## Motivation
 
-In debug mode SDL produce a lot of logs.
-Logging is asynchronous not to reduce efficiency of SDL business logic. 
-In some use cases (like video streaming orbit Put file) SDL produce more logs than it can write to file system. 
-SDL collect this logs in queue and write to file system in separate thread. 
-After receiving IGNITION_OFF signal currently SDL drop all logs that was not written yet.
-Such behavior prevents analyzing of SDL issues that found by ATF script by SDL logs, and requires adding additional timeouts in test scripts before SDL shutdown.
+In debug mode SDL produce a lot of logs in is asynchronous mode. 
+In some use cases (like video streaming or big Put file) SDL produce a lot of logs.
+SDL collect this logs in queue and write to file system in separate thread.
+Writing to file system may requir big amount of time.
+
+In current implementation after receiving IGNITION_OFF signal SDL drop all logs that was not written yet.
+Such behavior sometimes prevents analyzing of SDL issues that found by ATF script, and requires adding additional timeouts in test scripts before SDL shutdown.
 
 This is example of sequence in script:
 
@@ -29,7 +31,7 @@ PutFile(some_big_file)
 StopSDL()
 ```
 
-After run of this script with bit probability Logs of Put file request wind be written to SDL. 
+Logs of Put file request won't be written to file system, likey.
 To avoid such behavior script should be modified :
 ```
 StartSDL()
@@ -40,7 +42,7 @@ Sleep(SomeMagicTime)
 StopSDL()
 ```
 
-But SomeMagicTime will be different for different workstations and depend from operation system load.
+But `SomeMagicTime` will be different for different workstations and depend from operation system load.
 So this problem can be solved only with modifications on SDL side. 
 
 ## Proposed solution
@@ -67,7 +69,7 @@ N/A
 
 ## Impact on existing code
 
-Impact ignition off process of SDL core.
+Impacts ignition off process of SDL core.
 
 ## Alternatives considered
  1. Do not write all logs to SDL before shutdown ( some logs may  be missed)

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -9,16 +9,16 @@
 
 To prevent missing logs after SDL shutdown, additional ini file options should be added : 
  - Write all logs to file system before shutdown 
- - Maximum time of sdl shutting down
+ - Maximum time of SDL shutting down
  
 ## Motivation
 
 SDL produces a tone of logs in the asynchronous mode in some use cases (like video streaming or big put file),
-SDL collect these logs in queue and write to file system in a separate thread
+SDL collects these logs in queue and write them to file system in a separate thread.
 Writing to the file system may require big amount of time.
 
 In current implementation after receiving IGNITION_OFF signal SDL drops all logs that was not written yet.
-Such behavior sometimes prevents analyzing of SDL issues that found by ATF script, and requires requires adding extra timeouts in test scripts before SDL shutdown.
+Such behavior sometimes prevents analyzing of SDL issues that found by ATF script, and requires adding extra timeouts in test scripts before SDL shutdown.
 
 This is an example of sequence in script:
 
@@ -30,7 +30,7 @@ PutFile(some_big_file)
 StopSDL()
 ```
 
-Logs of Put file request won't be written to file system, ikely?
+Logs of Put file request won't be written to file system, likely.
 To avoid such behavior script should be modified :
 ```
 StartSDL()
@@ -53,7 +53,7 @@ So this problem can be solved only with modifications on SDL side.
 // Write all logs in queue to file system before shutdown 
 FlushLogMessagesBeforeShutdown = false
 
-// Maximum time to wait for writing all data before exit sdl in seconds
+// Maximum time to wait for writing all data before exit SDL in seconds
 MaxTimeBeforeShutdown = 30
 ```
 

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -7,17 +7,17 @@
 
 ## Introduction
 
-This proposal is about adding new parameters in ini file for configureing time to stopping SDL process after receiving Ignition off signal.
-And configuring option if SDL should write all logs to the file system before shudown. 
+This proposal is about adding new parameters in ini file for configuration time to stopping SDL process after receiving Ignition off signal.
+And configuring option if SDL should write all logs to the file system before shutdown. 
 
 ## Motivation
 
 In debug mode SDL produce a lot of logs.
-Logging is asyncronious not to reduce eficiency of SDL business loginc. 
-In some use cases (like videostreaming orbit Put file) SDL produce more logs than it can write to file system. 
+Logging is asynchronous not to reduce efficiency of SDL business logic. 
+In some use cases (like video streaming orbit Put file) SDL produce more logs than it can write to file system. 
 SDL collect this logs in queue and write to file system in separate thread. 
 After receiving IGNITION_OFF signal currently SDL drop all logs that was not written yet.
-Such behaviour prevents analysing of SDL issues that found by ATF script by SDL logs, and requires adding additional timouts in test scripts before SDL shutdown.
+Such behavior prevents analyzing of SDL issues that found by ATF script by SDL logs, and requires adding additional timeouts in test scripts before SDL shutdown.
 
 This is example of sequence in script:
 
@@ -30,7 +30,7 @@ StopSDL()
 ```
 
 After run of this script with bit probability Logs of Put file request wind be written to SDL. 
-To avoid such behaviour script should be modified :
+To avoid such behavior script should be modified :
 ```
 StartSDL()
 RegisterApplication()
@@ -49,7 +49,7 @@ So this problem can be solved only with modifications on SDL side.
  - Add option that specifies time maximum before shutdown.
 
 ```
-// Write all logs un queue to filesystem before shutdown 
+// Write all logs in queue to file system before shutdown 
 FushLogMessagesBeforeShutdown = false
 
 // Maximum time to wait for writing all data before exit sdl in seconds
@@ -58,7 +58,7 @@ MaxTimeBeforeShutdown = 30
 
 By default `FushLogMessagesBeforeShutdown` should be false. In that case SDL should not wait for writing all data to file system ans stop process after receiving `OnExitAllApplications` notification. 
 
-`MaxTimeBeforeShutdown` doe used in case if `FushLogMessagesBeforeShutdown` is `true`. It should measure timer from `OnExitAllApplications` notification received. In case if writing logs to file system takes moer than specified, SDL should terminate writing and finish process. 
+`MaxTimeBeforeShutdown` doe used in case if `FushLogMessagesBeforeShutdown` is `true`. It should measure timer from `OnExitAllApplications` notification received. In case if writing logs to file system takes more than specified, SDL should terminate writing and finish process. 
 
 
 ## Potential downsides
@@ -73,3 +73,4 @@ Impact ignition off process of SDL core.
  1. Do not write all logs to SDL before shutdown ( some logs may  be missed)
  2. Write all logs before shutdown ( shutdown may take a log time)
  
+

--- a/proposals/nnnn-configurable-time-before-shutdown.md
+++ b/proposals/nnnn-configurable-time-before-shutdown.md
@@ -7,21 +7,20 @@
 
 ## Introduction
 
-To prevent missing logs in SDL shutdown add Additional ini file options:
+To prevent missing logs after SDL shutdown, additional ini file options should be added : 
  - Write all logs to file system before shutdown 
  - Maximum time of sdl shutting down
  
 ## Motivation
 
-In debug mode SDL produce a lot of logs in is asynchronous mode. 
-In some use cases (like video streaming or big Put file) SDL produce a lot of logs.
-SDL collect this logs in queue and write to file system in separate thread.
-Writing to file system may requir big amount of time.
+SDL produces a tone of logs in the asynchronous mode in some use cases (like video streaming or big put file),
+SDL collect these logs in queue and write to file system in a separate thread
+Writing to the file system may require big amount of time.
 
-In current implementation after receiving IGNITION_OFF signal SDL drop all logs that was not written yet.
-Such behavior sometimes prevents analyzing of SDL issues that found by ATF script, and requires adding additional timeouts in test scripts before SDL shutdown.
+In current implementation after receiving IGNITION_OFF signal SDL drops all logs that was not written yet.
+Such behavior sometimes prevents analyzing of SDL issues that found by ATF script, and requires requires adding extra timeouts in test scripts before SDL shutdown.
 
-This is example of sequence in script:
+This is an example of sequence in script:
 
 ```
 StartSDL()
@@ -31,36 +30,36 @@ PutFile(some_big_file)
 StopSDL()
 ```
 
-Logs of Put file request won't be written to file system, likey.
+Logs of Put file request won't be written to file system, ikely?
 To avoid such behavior script should be modified :
 ```
 StartSDL()
 RegisterApplication()
 ActivateApplication
 PutFile(some_big_file)
-Sleep(SomeMagicTime)
+Sleep(SomeUndefinedTime)
 StopSDL()
 ```
 
-But `SomeMagicTime` will be different for different workstations and depend from operation system load.
+But `SomeUndefinedTime` will be different for different workstations and depend on operation system load.
 So this problem can be solved only with modifications on SDL side. 
 
 ## Proposed solution
 
  - Add option to flush log messages before shutdown.
- - Add option that specifies time maximum before shutdown.
+ - Add option that specifies maximum time before shutdown.
 
 ```
 // Write all logs in queue to file system before shutdown 
-FushLogMessagesBeforeShutdown = false
+FlushLogMessagesBeforeShutdown = false
 
 // Maximum time to wait for writing all data before exit sdl in seconds
 MaxTimeBeforeShutdown = 30
 ```
 
-By default `FushLogMessagesBeforeShutdown` should be false. In that case SDL should not wait for writing all data to file system ans stop process after receiving `OnExitAllApplications` notification. 
+By default `FlushLogMessagesBeforeShutdown` should be false. In that case SDL should not wait for writing all data to file system ans stop process after receiving `OnExitAllApplications` notification. 
 
-`MaxTimeBeforeShutdown` doe used in case if `FushLogMessagesBeforeShutdown` is `true`. It should measure timer from `OnExitAllApplications` notification received. In case if writing logs to file system takes more than specified, SDL should terminate writing and finish process. 
+`MaxTimeBeforeShutdown` would be used in case if `FlushLogMessagesBeforeShutdown` is `true`. It should measure time from `OnExitAllApplications` notification received. In case if writing logs to file system takes more time than specified, SDL should terminate writing and finish process. 
 
 
 ## Potential downsides
@@ -73,6 +72,6 @@ Impacts ignition off process of SDL core.
 
 ## Alternatives considered
  1. Do not write all logs to SDL before shutdown ( some logs may  be missed)
- 2. Write all logs before shutdown ( shutdown may take a log time)
+ 2. Write all logs before shutdown ( shutdown may take a long time)
  
 


### PR DESCRIPTION
To prevent missing logs in SDL shutdown add Additional ini file options:
 - Write all logs to file system before shutdown 
 - Maximum time of sdl shutting down

