### PR TITLE
Revise SDL 0138: Make 'audioPassThruCapabilities' of HMI an array

### DIFF
--- a/proposals/0138-hmi-audiopassthru-capability.md
+++ b/proposals/0138-hmi-audiopassthru-capability.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-This document proposes to change `audioPassThruCapabilities` parameter in `UI.GetCapabilities` response and hmi\_capabilities.json file to an array.
+This document proposes to update AudioPassThru capability parameter in `UI.GetCapabilities` response and hmi\_capabilities.json file to an array.
 
 ## Motivation
 
@@ -18,7 +18,9 @@ On the other hand, `audioPassThruCapabilities` parameter in `UI.GetCapabilities`
 
 ## Proposed solution
 
-To resolve the inconsistency, this document proposes to update HMI\_API.xml so that `audioPassThruCapabilities` parameter is defined as an array.
+To resolve the inconsistency, this document proposes to append a parameter called `audioPassThruCapabilitiesList` in HMI\_API.xml. The parameter is defined as an array.
+
+Note that the old `audioPassThruCapabilities` parameter is left intact so that we do not break compatibility. SDL Core tries to read both `audioPassThruCapabilitiesList` and `audioPassThruCapabilities` parameters. If `audioPassThruCapabilitiesList` is available, Core uses it instead of `audioPassThruCapabilities`.
 
 It is also proposed to update hmi\_capabilities.json file, so that head unit developers will be aware that HMI can return multiple recording capabilities.
 
@@ -29,7 +31,7 @@ It is also proposed to update hmi\_capabilities.json file, so that head unit dev
 
 ```diff
 -<interface name="UI" version="1.2.0" date="2017-09-05">
-+<interface name="UI" version="1.3.0" date="2018-01-24">
++<interface name="UI" version="1.3.0" date="2018-02-13">
  
    :
  
@@ -38,7 +40,17 @@ It is also proposed to update hmi\_capabilities.json file, so that head unit dev
      :
  
 -    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" mandatory="true"/>
-+    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" minsize="1" maxsize="100" array="true" mandatory="true"/>
++    <param name="audioPassThruCapabilities" type="Common.AudioPassThruCapabilities" mandatory="true">
++      <description>
++        Describes an audio configuration that the system supports for PerformAudioPassThru.
++        Note: please fill out both audioPassThruCapabilities and audioPassThruCapabilitiesList parameters, as:
++        - Newer SDL Core uses audioPassThruCapabilitiesList instead of audioPassThruCapabilities.
++        - audioPassThruCapabilities is a mandatory field and cannot be omitted.
++      </description>
++    </param>
++    <param name="audioPassThruCapabilitiesList" type="Common.AudioPassThruCapabilities" minsize="1" maxsize="100" array="true">
++      <description>Describes the audio configurations that the system supports for PerformAudioPassThru.</description>
++    </param>
 ```
 
 Note: no change is required for MOBILE\_API.xml.
@@ -46,7 +58,9 @@ Note: no change is required for MOBILE\_API.xml.
 
 ### Modification of Core
 
-Update src/appMain/hmi\_capabilities.json file as follows:
+The logic to acquire AudioPassThru capability information is updated to check `audioPassThruCapabilitiesList` first, then `audioPassThruCapabilities`.
+
+Also, update src/appMain/hmi\_capabilities.json file as follows:
 ```diff
  {
      "UI": {
@@ -62,7 +76,7 @@ Update src/appMain/hmi\_capabilities.json file as follows:
 +        }],
 ```
 
-Also, HMICapabilitiesImpl::load\_capabilities\_from\_file() should be update to read `audioPassThruCapabilities` as an array.
+HMICapabilitiesImpl::load\_capabilities\_from\_file() should be update to read `audioPassThruCapabilities` as an array.
 
 
 ## Potential downsides
@@ -71,11 +85,12 @@ The author does not come up with any potential downsides.
 
 ## Impact on existing code
 
-Core: only the code inside HMICapabilitiesImpl::load\_capabilities\_from\_file() is affected.
+Core: the logic to acquire AudioPassThru parameter from HMI and from hmi\_capabilities.json file is affected.
 
-HMI: update on `UI.GetCapabilities` implementation is required as the change in HMI\_API.xml is not backward compatible. When new SDL Core is installed on the head unit, OEMs should update their HMIs at the same time.
+HMI: not affected. However, it is recommended to update its implementation to use new `audioPassThruCapabilitiesList` parameter.
 
 ## Alternatives considered
 
-- Append an optional parameter in `UI.GetCapabilities` response, such as "audioPassThruCapabilities2", to keep backward compatibility. This seems more confusing to developers as we have two similar parameters, one is mandatory and another is optional.
+- Change `audioPassThruCapabilities` parameter to an array.<br>
+  Originally the author created this proposal based on this idea and received concerns that it breaks compatibility.
 - Keep current HMI\_API.xml. This approach does not support a head unit that is capable of (and wants to provide) multiple recording capabilities.


### PR DESCRIPTION
This document proposes to update AudioPassThru capability parameter in `UI.GetCapabilities` response and hmi_capabilities.json file to an array.