### PR TITLE
Accepted multiple transport proposal: Addition of ini entry and amending header of Register Secondary Transport NAK

### DIFF
--- a/proposals/0141-multiple-transports.md
+++ b/proposals/0141-multiple-transports.md
@@ -117,9 +117,9 @@ Max major version<br>supported by module and application | no | Control    | Con
 
 The header field of `Register Secondary Transport NAK` frame is shown below.
 
-Version                                                  | E  | Frame Type | Service Type | Frame Info                          | Session Id                               | Data Size       | Message ID
----------------------------------------------------------|----|------------|--------------|-------------------------------------|------------------------------------------|-----------------|-----------
-Max major version<br>supported by module and application | no | Control    | Control      | Register Secondary<br>Transport NAK | Session Id assigned on<br>Primary Transport | Size of payload | 2
+Version                                                                           | E  | Frame Type | Service Type | Frame Info                          | Session Id                               | Data Size       | Message ID
+----------------------------------------------------------------------------------|----|------------|--------------|-------------------------------------|------------------------------------------|-----------------|-----------
+Max major version<br>supported by module and application if<br>known, otherwise 5 | no | Control    | Control      | Register Secondary<br>Transport NAK | Session Id assigned on<br>Primary Transport | Size of payload | 2
 
 `Register Secondary Transport NAK` frame includes following parameter:
 
@@ -258,6 +258,15 @@ SecondaryTransportForWiFi =
 ; Video service
 0x0B = TCP_WIFI, IAP_CARPLAY, IAP_USB_HOST_MODE, IAP_USB_DEVICE_MODE, IAP_USB, AOA_USB
 ```
+```ini
+[TransportManager]
+  :
+(snip)
+  :
+; Name of the network interface that Core will listen on for incoming TCP connection, e.g. eth0.
+; If the name is omitted, Core will listen on all network interfaces by binding to INADDR_ANY.
+TCPAdapterNetworkInterface =
+```
 
 
 ### Modification of HMI\_API.xml
@@ -299,7 +308,6 @@ Note: these behaviors are already seen on current SDL Core when an app on a phon
 ## Out of scope of this proposal
 
 - The authors have a use-case to prevent a video-streaming app from automatically launching on HMI if it is not connected with a high-bandwidth transport (i.e. Wi-Fi or USB). To realize this use-case, the resumption logic in SDL Core has to be modified. This feature will be addressed in another proposal [SDL-nnnn: Add capability to disable or reject an app based on app type, transport type and OS type][reg_limitation].
-- In some cases, SDL Core should not accept TCP connections on all network interfaces. For example, a head unit is equipped with a Wi-Fi network device and a communication module for cellular network, in which case the system will have two network interfaces. An OEM may want to accept SDL connection only through Wi-Fi's network interface and not through Internet connection. If we need to support such scenario, another proposal should be entered.
 
 
 ## Alternatives considered


### PR DESCRIPTION
# Accepted multiple transport proposal: Addition of ini entry and amending header of Register Secondary Transport NAK

* Altered Proposal: [SDL-0141](0141-multiple-transports.md)
* Author: [Sho Amano](https://github.com/shoamano83)
* Status: **Accepted**
* Impacted Platforms of the changes: [Core / Protocol]

## Introduction

While implementing [SDL-0141](0141-multiple-transports.md), the author noticed a few implementation details which can be reflected to the proposal document for clarification. This Pull Request is to address the update of the document.

## Motivation

1. Specifying network interface name in smartDeviceLink.ini file

As the original document of [SDL-0141](0141-multiple-transports.md) stated in 'Out of scope of this proposal' section, some head units may require using a specific network interface to accept incoming TCP connection. After investigating the source code, the author thinks that it can be implemented without making impacts on RPC spec. The only issue is that we lack the means to specify the network interface name. The author thinks that adding an entry in smartDeviceLink.ini file is the straightforward way.

2. Using protocol version 5 in `Register Secondary Transport NAK` frame if negotiated version is unknown

The original document was written in mind that Proxy would always send correct Session ID in `Register Secondary Transport` frame. If, for some reasons, Core received a `Register Secondary Transport` frame with an invalid Session ID (0 for example), then Core had no way to determine the negotiated version, as it couldn't identify the mobile app that was communicating.

In this corner case, the author thinks using version 5 is appropriate. The version number is chosen because:
- we need at least version 5 to include payload in the frame.
- `Register Secondary Transport` frame has been added in version 5.1.0, so there should be no problem to send a version 5 frame to Proxy.


## Proposed solution

- Append following entry in smartDeviceLink.ini to specify the name of the network interface:
```ini
[TransportManager]
  :
(snip)
  :
; Name of the network interface that Core will listen on for incoming TCP connection, e.g. eth0.
; If the name is omitted, Core will listen on all network interfaces by binding to INADDR_ANY.
TCPAdapterNetworkInterface =
```

- Remove following paragraph from 'Out of scope of this proposal' section as the scenario has been addressed:

> In some cases, SDL Core should not accept TCP connections on all network interfaces. For example, a head unit is equipped with a Wi-Fi network device and a communication module for cellular network, in which case the system will have two network interfaces. An OEM may want to accept SDL connection only through Wi-Fi's network interface and not through Internet connection. If we need to support such scenario, another proposal should be entered.


- In the table describing `Register Secondary Transport NAK` frame, amend the `Version` field from:

> Max major version supported by module and application

to:

> Max major version supported by module and application if known, otherwise 5

## Potential downsides

The author did not come up with any potential downsides.

## Impact on existing code

This Pull Request will introduce additional implementation in Core to fetch the new entry in smartDeviceLink.ini file.

## Alternatives considered

N/A