### PR TITLE
Revise SDL 0149 "Add capability to disable resumption based on app type and transport type"

### DIFF
--- a/proposals/0149-mt-registration-limitation.md
+++ b/proposals/0149-mt-registration-limitation.md
@@ -44,8 +44,8 @@ smartDeviceLink.ini includes following new sections. (Note: the default values a
 ; the transports listed, its HMIlevel will be kept in NONE and the state stays in NOT_AUDIBLE.
 ; In case an app has multiple AppHMIType, requirements of all of the AppHMITypes are applied.
 ;
-; Possible AppHMITypes: DEFAULT, COMMUNICATION, MEDIA, MESSAGING, NAVIGATION, INFORMATION, SOCIAL,
-;                       BACKGROUND_PROCESS, TESTING, SYSTEM, PROJECTION, REMOTE_CONTROL, NONE
+; Possible AppHMITypes: Default, Communication, Media, Messaging, Navigation, Information, Social,
+;                       BackgroundProcess, Testing, System, Projection, RemoteControl, EmptyApp
 ; Possible transport types: TCP_WIFI, IAP_CARPLAY, IAP_USB_HOST_MODE, IAP_USB_DEVICE_MODE, IAP_USB,
 ;                           AOA_USB, IAP_BLUETOOTH, SPP_BLUETOOTH
 ;
@@ -58,20 +58,20 @@ smartDeviceLink.ini includes following new sections. (Note: the default values a
 ; exception. When these apps do not have any of the transports listed here, they will be still
 ; resumed into particular HMIlevel defined in LowBandwidthTransportResumptionLevel section.
 
-; DEFAULT =
-; COMMUNICATION =
-; MEDIA =
-; MESSAGING =
-NAVIGATION = TCP_WIFI, IAP_CARPLAY, IAP_USB_HOST_MODE, IAP_USB_DEVICE_MODE, IAP_USB, AOA_USB
-; INFORMATION =
-; SOCIAL =
-; BACKGROUND_PROCESS =
-; TESTING =
-; SYSTEM =
-PROJECTION = TCP_WIFI, IAP_CARPLAY, IAP_USB_HOST_MODE, IAP_USB_DEVICE_MODE, IAP_USB, AOA_USB
-; REMOTE_CONTROL =
-; "NONE" applies to apps that don't specify any AppHMIType
-; NONE =
+; DefaultTransportRequiredForResumption =
+; CommunicationTransportRequiredForResumption =
+; MediaTransportRequiredForResumption =
+; MessagingTransportRequiredForResumption =
+NavigationTransportRequiredForResumption = TCP_WIFI, IAP_CARPLAY, IAP_USB_HOST_MODE, IAP_USB_DEVICE_MODE, IAP_USB, AOA_USB
+; InformationTransportRequiredForResumption =
+; SocialTransportRequiredForResumption =
+; BackgroundProcessTransportRequiredForResumption =
+; TestingTransportRequiredForResumption =
+; SystemTransportRequiredForResumption =
+ProjectionTransportRequiredForResumption = TCP_WIFI, IAP_CARPLAY, IAP_USB_HOST_MODE, IAP_USB_DEVICE_MODE, IAP_USB, AOA_USB
+; RemoteControlTransportRequiredForResumption =
+; "EmptyAppTransportRequiredForResumption" applies to apps that don't specify any AppHMIType
+; EmptyAppTransportRequiredForResumption =
 
 [LowBandwidthTransportResumptionLevel]
 ; The HMI Level that an app will resume to if no high bandwidth connection is active.

--- a/proposals/0149-mt-registration-limitation.md
+++ b/proposals/0149-mt-registration-limitation.md
@@ -18,7 +18,7 @@ In such cases, it is possible that the mobile projection app will connect throug
 
 This document proposes to disable resumption feature in such case, so that HMI will not show the app until Secondary Transport is connected (and video streaming is eventually started.) HMI will stay on another screen, for example app selection list. Also, HMI may implement an error message stating that Wi-Fi or USB transport is required for a mobile projection app to work.
 
-In addition, this document also proposes to add another configuration to resume video streaming and media apps to particular HMI level while the high-bandwidth transport isn't available. This will be useful for OEMs who want to let a navigation app running in LIMITED level before Wi-Fi transport is established, while avoiding an empty screen being shown on HMI.
+In addition, this document also proposes to add another configuration to resume video streaming and media apps to a particular HMI level when the high-bandwidth transport isn't available. This will be useful for OEMs who want to let a navigation app run in LIMITED HMILevel before a Wi-Fi transport is established, while avoiding an empty screen being shown on HMI.
 
 Note: the author thinks the resumption procedure has two stages. The first stage is that Core restores an app's HMILevel to non-NONE after the app is registered. The second stage is that Core restores the app's data based on stored information and Hash ID sent by the app. We discuss the first stage in this document. The term "disable resumption" means that Core doesn't restore an app's HMILevel after registration.
 


### PR DESCRIPTION
This document proposes to add an advanced feature to disable or limit resumption feature based on AppHMIType and transport type. This is related to proposal SDL-0141: Supporting simultaneous multiple transports.