### PR TITLE
New rules for processing AddCommand for providing vrHelp items and title

### DIFF
--- a/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
+++ b/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
@@ -25,8 +25,10 @@ The proposed mechanism is detailed below:
 	1. construct the `vrHelp` parameter using the data from the list SDL Core internally created.
   	2. construct the `helpPrompt` parameter using the data from the list SDL Core internally created.
   	3. then send these parameters to the HMI via the `SetGlobalProperties` RPC.
-5. If after SDL Core sends the `SetGlobalProperties` RPC, applications sends further AddCommmand/DeleteCommand requests then SDL Core shall send `SetGlobalProperties` with the updated parameters.(The full list of parameters needs to be sent and not just the recently added one).
-6. If at any point in time, the applications sends `SetGlobalProperties` RPC with the `vrHelp` **and** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall delete its internal list and stop sending `SetGlobalProperties` RPC to HMI after each AddCommmand/DeleteCommand requests received from mobile.
+5. If after SDL Core sends the `SetGlobalProperties` RPC, applications sends further AddCommand/DeleteCommand requests then SDL Core shall send `SetGlobalProperties` with the updated parameters.(The full list of parameters needs to be sent and not just the recently added one).
+The limitation for processing AddCommand and providing updated values of "vrHelp" and "helpPrompt" to HMI until the mobile application sends SetGlobalProperties request is 30.
+Update values of "vrHelp" and "helpPrompt" via TTS UI.SetGlobalProperties to HMI only by receiving AddCommand with CommandType = Command. AddCommand requests related to choice set must not trigger the update of "vrHelp" and "helpPrompt" values.
+6. If at any point in time, the applications sends `SetGlobalProperties` RPC with the `vrHelp` **and** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall delete its internal list and stop sending `SetGlobalProperties` RPC to HMI after each AddCommand/DeleteCommand requests received from mobile.
 
 7. If at any point in time, the applications sends `SetGlobalProperties` RPC with **either** of `vrHelp` **or** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall not delete its internal list and shall continue to update the parameter which was not provided by the application.
 8. The same process shall be followed during application resumption as well.
@@ -45,7 +47,7 @@ Create HelpPromptManager with following interface:
  ![Class diagram](/assets/proposals/0122-new_rules_for_providing_vr_help_items_vr_help_title/0122-New_rules_for_providing_VRHelpItems_VRHelpTitl.png##)
 
  This implementation approach won't affect current implementation of Global properties and Add\Delete command.
- 
+
 ## Potential downsides
 
 N/A


### PR DESCRIPTION
Added information about limitation for addCommands and processed addCommand type according to https://github.com/smartdevicelink/sdl_evolution/issues/364.