### PR TITLE
Accepted handling VR help requests proposal: Conditions for using the default values for helpPrompt and vrHelp parameters and update the default value for vrHelp in ini file

### DIFF
--- a/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
+++ b/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
@@ -29,11 +29,11 @@ The proposed mechanism is detailed below:
 	1. construct the vrHelp parameter using default data from .ini file, e.g. "Unfortunately application has no available commands".
   	2. construct the helpPrompt parameter using the default data from .ini file, e.g. "Please speak one of the following commands".
   	3. then send these parameters to the HMI via the `SetGlobalProperties` RPC.
-6. If after SDL Core sends the `SetGlobalProperties` RPC, applications sends further AddCommand/DeleteCommand requests then SDL Core shall send `SetGlobalProperties` with the updated parameters.(The full list of parameters needs to be sent and not just the recently added one).
+6. If after SDL Core sends the `SetGlobalProperties` RPC, the application sends further AddCommand/DeleteCommand requests then SDL Core shall send `SetGlobalProperties` with the updated parameters.(The full list of parameters needs to be sent and not just the recently added one).
 The limitation for processing AddCommand and providing updated values of "vrHelp" and "helpPrompt" to HMI until the mobile application sends SetGlobalProperties request is 30.
 Update values of "vrHelp" and "helpPrompt" via TTS UI.SetGlobalProperties to HMI only by receiving AddCommand with CommandType = Command. AddCommand requests related to choice set must not trigger the update of "vrHelp" and "helpPrompt" values.
-7. If at any point in time, the applications sends `SetGlobalProperties` RPC with the `vrHelp` **and** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall delete its internal list and stop sending `SetGlobalProperties` RPC to HMI after each AddCommmand/DeleteCommand requests received from mobile.
-8. If at any point in time, the applications sends `SetGlobalProperties` RPC with **either** of `vrHelp` **or** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall not delete its internal list and shall continue to update the parameter which was not provided by the application.
+7. If at any point in time, the application sends `SetGlobalProperties` RPC with the `vrHelp` **and** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall delete its internal list and stop sending `SetGlobalProperties` RPC to HMI after each AddCommmand/DeleteCommand request received from mobile.
+8. If at any point in time, the application sends `SetGlobalProperties` RPC with **either** of `vrHelp` **or** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall not delete its internal list and shall continue to update the parameter which was not provided by the application.
 9. The same process shall be followed during application resumption as well.
 
 Note:

--- a/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
+++ b/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
@@ -25,13 +25,16 @@ The proposed mechanism is detailed below:
 	1. construct the `vrHelp` parameter using the data from the list SDL Core internally created.
   	2. construct the `helpPrompt` parameter using the data from the list SDL Core internally created.
   	3. then send these parameters to the HMI via the `SetGlobalProperties` RPC.
-5. If after SDL Core sends the `SetGlobalProperties` RPC, applications sends further AddCommand/DeleteCommand requests then SDL Core shall send `SetGlobalProperties` with the updated parameters.(The full list of parameters needs to be sent and not just the recently added one).
+5. If the timer times out and mobile application does not send SetGlobalProperties and AddCommand requests SDL shall:
+	1. construct the vrHelp parameter using default data from .ini file, e.g. "Unfortunately application has no available commands".
+  	2. construct the helpPrompt parameter using the default data from .ini file, e.g. "Please speak one of the following commands".
+  	3. then send these parameters to the HMI via the `SetGlobalProperties` RPC.
+6. If after SDL Core sends the `SetGlobalProperties` RPC, applications sends further AddCommand/DeleteCommand requests then SDL Core shall send `SetGlobalProperties` with the updated parameters.(The full list of parameters needs to be sent and not just the recently added one).
 The limitation for processing AddCommand and providing updated values of "vrHelp" and "helpPrompt" to HMI until the mobile application sends SetGlobalProperties request is 30.
 Update values of "vrHelp" and "helpPrompt" via TTS UI.SetGlobalProperties to HMI only by receiving AddCommand with CommandType = Command. AddCommand requests related to choice set must not trigger the update of "vrHelp" and "helpPrompt" values.
-6. If at any point in time, the applications sends `SetGlobalProperties` RPC with the `vrHelp` **and** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall delete its internal list and stop sending `SetGlobalProperties` RPC to HMI after each AddCommand/DeleteCommand requests received from mobile.
-
-7. If at any point in time, the applications sends `SetGlobalProperties` RPC with **either** of `vrHelp` **or** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall not delete its internal list and shall continue to update the parameter which was not provided by the application.
-8. The same process shall be followed during application resumption as well.
+7. If at any point in time, the applications sends `SetGlobalProperties` RPC with the `vrHelp` **and** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall delete its internal list and stop sending `SetGlobalProperties` RPC to HMI after each AddCommmand/DeleteCommand requests received from mobile.
+8. If at any point in time, the applications sends `SetGlobalProperties` RPC with **either** of `vrHelp` **or** `helpPrompt` parameters, then SDL Core shall continue with the existing behavior of forwarding such requests to HMI and SDL Core shall not delete its internal list and shall continue to update the parameter which was not provided by the application.
+9. The same process shall be followed during application resumption as well.
 
 Note:
 10 second timer:


### PR DESCRIPTION
# Accepted handling VR help requests proposal: Conditions for using the default values for helpPrompt and vrHelp parameters and update the default value for vrHelp in ini file

* Proposal: [SDL-0122](0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md)
* Author: [Irina Getmanets](https://github.com/GetmanetsIrina)
* Status: **Awaiting review**
* Impacted Platforms: Core, Protocol

## Introduction
While creation testing coverage for [SDL-0122](0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md), the author noticed a few requirement details which can be reflected to the proposal document for clarification. This Pull Request is to address the update of the document.

## Motivation
According to requirements in the proposal we still can have situation when the registered app will not have the help messages.
In case the app is registered and does not add any commands after the timer times out there are no values for the `helpPrompt` and `vrHelp` parameters for  the `SetGlobalProperties` RPC from SDL. 

## Proposed solution
1. smartDeviceLink.ini file must have default messages for the `helpPrompt` and `vrHelp` parameters:
      1. `HelpPrompt = Please speak one of the following commands,Please say a command`
       2. `HelpCommand = Unfortunately application has no available commands`
2. SDL must use default values for the `helpPrompt` and `vrHelp` parameters for the `SetGlobalProperties` RPC from SDL when the timer times out.

For now the `HelpPrompt` and `HelpCommand` parameters are present in smartDeviceLink.ini, so it is only required to update the value for HelpCommand parameter and consider the requirement changes during the implementation.

## Potential downsides
N/A

## Impact on existing code
This Pull Request will introduce additional requirements for future implementation in Core  and update of the `HelpCommand` value in smartDeviceLink.ini file.

## Alternatives considered
N/A
