### PR TITLE
Revise SDL-0150 - Video Streaming State

### DIFF
--- a/proposals/0150-video-streaming-state.md
+++ b/proposals/0150-video-streaming-state.md
@@ -78,7 +78,7 @@ The transition of videoStreamingState and audioStreamingState is independent of 
     </param>
     
     <!-- new additions-->
-    <param name="videoStreamingState" type="VideoStreamingState" mandatory="false">
+    <param name="videoStreamingState" type="VideoStreamingState" mandatory="false" defvalue="STREAMABLE">
         <description>See VideoStreamingState. 
         If it is NOT_STREAMABLE, the app must stop streaming video to SDL Core(stop service).
         </description>

--- a/proposals/0150-video-streaming-state.md
+++ b/proposals/0150-video-streaming-state.md
@@ -78,7 +78,7 @@ The transition of videoStreamingState and audioStreamingState is independent of 
     </param>
     
     <!-- new additions-->
-    <param name="videoStreamingState" type="VideoStreamingState" mandatory="true">
+    <param name="videoStreamingState" type="VideoStreamingState" mandatory="false">
         <description>See VideoStreamingState. 
         If it is NOT_STREAMABLE, the app must stop streaming video to SDL Core(stop service).
         </description>


### PR DESCRIPTION
# Revise SDL-0150 - Video Streaming State

## Introduction

Alter `videoStreamingState` to be optional instead of mandatory.

## Motivation

The existing proposal is a major RPC version change and causes high impact backward compatibility issues that are very difficult to mitigate.

## Proposed solution

Change the `videoStreamingState` parameter to optional.

## Potential downsides

None the author could identify.

## Impact on existing code

Makes a major version change into a minor version change.

## Alternatives considered

No alternatives were considered.