### PR TITLE
Update SDL-Android minimum SDK

### DIFF
--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -31,4 +31,4 @@ Change the min SDK in the `build.gradle` file.
 
 ## Alternatives considered
 
-Raising the min SDK to a number higher than 8 but less than 19 was considered. However, distribution on those versions are on average less that 1% of the entire Android ecosystem. SDK 19 is generally regarded as a comfortable minimum SDK.
+Raising the min SDK to a number higher than 8 but less than 19 was considered. However, distribution on those versions are on average less than 1% of the entire Android ecosystem. SDK 19 is generally regarded as a comfortable minimum SDK.

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -1,8 +1,8 @@
 # Update SDL-Android minimum SDK
 
-* Proposal: [SDL-XXX](XXXX-update-android-min-sdk.md)
-* Author: [Bretty White](https://github.com/brettywhite)
-* Status: **Awaiting Acceptance**
+* Proposal: [SDL-NNNN](XXXX-update-android-min-sdk.md)
+* Author: [Brett M.](https://github.com/brettywhite)
+* Status: **Awaiting Review**
 * Impacted Platforms: Android
 
 ## Introduction
@@ -21,7 +21,7 @@ Because this is a major change, it would need to be implemented in SDL Android's
 
 The current minimum SDK 8 was released in 2010. SDK 16 was released in 2012. In comparison, the current SDL iOS's minimum deployment target is 8, which was released in 2014. Both SDK 16 and iOS deployment target 8 have similar numbers in terms of devices not supported (<= 0.5%).
 
-Having our minimum at 16 will help with managers as well. It will allow a more streamlined audio stremaing manager, for example, by not having to create any *coding tricks* (read: messy code) to make it work with lower unsupported APIs.
+Having our minimum at 16 will help with managers as well. It will allow a more streamlined audio streaming manager, for example, by not having to create any *coding tricks* (read: messy code) to make it work with lower unsupported APIs.
 
 A much larger reason, however, is for testing. The library should, as it is being updated, test against all supported SDKs. It is difficult to find phones that go back to SDK 8, adding to testing cost, time and complexity - for very little in return in terms of additional devices being supported.
 
@@ -32,7 +32,7 @@ We potentially leave out 0.5% of Android devices. However, many developers now o
 
 ## Impact on existing code
 
-Change the min SDK in the `build.gradle` file.
+Change the min SDK in the `build.gradle` file. As stated earlier, it is a major version change and should target SDL Android v5.0.
 
 ## Alternatives considered
 

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -22,7 +22,7 @@ Because this is a major change, it would need to be implemented in SDL Android's
 
 ## Potential downsides
 
-We potentially leave out 4.1% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that is a non-issue.
+We potentially leave out 4.1% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that this is a non-issue.
 
 
 ## Impact on existing code

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -27,13 +27,11 @@ A much larger reason, however, is for testing. The library should, as it is bein
 
 ## Potential downsides
 
-We potentially leave out 0.5% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that this is a non-issue.
-
+We potentially leave out 0.5% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that this is a non-issue. As stated earlier, it is a major version change and should target SDL Android v5.0. This means there will be a wait before developers can enjoy the newer minimum.
 
 ## Impact on existing code
 
-Change the min SDK in the `build.gradle` file. As stated earlier, it is a major version change and should target SDL Android v5.0.
-
+Change the min SDK in the `build.gradle` file. 
 ## Alternatives considered
 
 Raising the min SDK to a number higher than 8 but less than 16 was considered. However, distribution on those versions are on average less than 0.5% of the entire Android ecosystem.

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -19,8 +19,9 @@ The proposed solution is to raise the minimum SDK from 8 to 16. According to [An
 
 Because this is a major change, it would need to be implemented in SDL Android's 5.0 release.
 
-Why 16 and not something lower? Because this covers almost every Android phone in use today. Minimum version changes are major version changes in semantic versioning, and this will also future-proof our library into SDL Android Version 6, sometime in the distant future.
+The current minimum SDK 8 was released in 2010. SDK 16 was released in 2012. In comparison, the current SDL iOS's minimum deployment target is 8, which was released in 2014. Both SDK 16 and iOS deployment target 8 have similar numbers in terms of devices not supported (<= 0.5%).
 
+Why 16 and not something lower? Because this covers almost every Android phone in use today. Minimum version changes are major version changes in semantic versioning, and this will also future-proof our library into SDL Android Version 6, sometime in the distant future.
 
 ## Potential downsides
 

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-With the progression of SDL Android as a library, it has become necessary to update the minimum supported SDK from 8. The proposed updated minimum SDK will be API 19, KitKat. 
+With the progression of SDL Android as a library, it has become necessary to update the minimum supported SDK from 8. The proposed minimum SDK will be API 19, KitKat. 
 
 ## Motivation
 

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -1,0 +1,34 @@
+# Update SDL-Android minimum SDK
+
+* Proposal: [SDL-XXX](XXXX-update-android-min-sdk.md)
+* Author: [Bretty White](https://github.com/brettywhite)
+* Status: **Awaiting Acceptance**
+* Impacted Platforms: Android
+
+## Introduction
+
+With the progression of SDL Android as a library, it has become necessary to update the minimum supported SDK from 8. The proposed updated minimum SDK will be API 19, KitKat. 
+
+## Motivation
+
+Maintaining backwards compatibility is often a double edged sword. While it is important for SDL libraries to be able to be used on the widest array of phones possible, maintaining old APIs and not being able to use newer ones comes at a cost of additional time and a reduction in forward movement.
+
+## Proposed solution
+
+The proposed solution is to raise the minimum SDK from 8 to 19. According to [Android's Dashboard](https://developer.android.com/about/dashboards/), 95.9% of all Android devices run SDK 19 or newer. 
+
+Because this is a major change, it would need to be implemented in SDL Android's 5.0 release.
+
+
+## Potential downsides
+
+We potentially leave out 4.1% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that is a non-issue.
+
+
+## Impact on existing code
+
+Change the min SDK in the `build.gradle` file.
+
+## Alternatives considered
+
+Raising the min SDK to a number higher than 8 but less than 19 was considered. However, distribution on those versions are on average less that 1% of the entire Android ecosystem. SDK 19 is generally regarded as a comfortable minimum SDK.

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -21,7 +21,9 @@ Because this is a major change, it would need to be implemented in SDL Android's
 
 The current minimum SDK 8 was released in 2010. SDK 16 was released in 2012. In comparison, the current SDL iOS's minimum deployment target is 8, which was released in 2014. Both SDK 16 and iOS deployment target 8 have similar numbers in terms of devices not supported (<= 0.5%).
 
-Why 16 and not something lower? Because this covers almost every Android phone in use today. Minimum version changes are major version changes in semantic versioning, and this will also future-proof our library into SDL Android Version 6, sometime in the distant future.
+Having our minimum at 16 will help with managers as well. It will allow a more streamlined audio stremaing manager, for example, by not having to create any *coding tricks* (read: messy code) to make it work with lower unsupported APIs.
+
+A much larger reason, however, is for testing. The library should, as it is being updated, test against all supported SDKs. It is difficult to find phones that go back to SDK 8, adding to testing cost, time and complexity - for very little in return in terms of additional devices being supported.
 
 ## Potential downsides
 

--- a/proposals/XXXX-update-android-min-sdk.md
+++ b/proposals/XXXX-update-android-min-sdk.md
@@ -7,22 +7,24 @@
 
 ## Introduction
 
-With the progression of SDL Android as a library, it has become necessary to update the minimum supported SDK from 8. The proposed minimum SDK will be API 19, KitKat. 
+With the progression of SDL Android as a library, it has become necessary to update the minimum supported SDK from 8. The proposed minimum SDK will be API 16, Jelly Bean. 
 
 ## Motivation
 
-Maintaining backwards compatibility is often a double edged sword. While it is important for SDL libraries to be able to be used on the widest array of phones possible, maintaining old APIs and not being able to use newer ones comes at a cost of additional time and a reduction in forward movement.
+Maintaining backwards compatibility is often a double edged sword. While it is important for SDL libraries to be able to be used on the widest array of phones possible, maintaining old APIs and not being able to use newer ones comes at a cost of additional time and a reduction in forward movement. This allows the use of newer libraries, such as `ConstraintLayout` that are not usable in the current SDL Android library because its' minimum SDK is higher than our own.
 
 ## Proposed solution
 
-The proposed solution is to raise the minimum SDK from 8 to 19. According to [Android's Dashboard](https://developer.android.com/about/dashboards/), 95.9% of all Android devices run SDK 19 or newer. 
+The proposed solution is to raise the minimum SDK from 8 to 16. According to [Android's Dashboard](https://developer.android.com/about/dashboards/), 99.5% of all Android devices run SDK 16 or newer. 
 
 Because this is a major change, it would need to be implemented in SDL Android's 5.0 release.
+
+Why 16 and not something lower? Because this covers almost every Android phone in use today. Minimum version changes are major version changes in semantic versioning, and this will also future-proof our library into SDL Android Version 6, sometime in the distant future.
 
 
 ## Potential downsides
 
-We potentially leave out 4.1% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that this is a non-issue.
+We potentially leave out 0.5% of Android devices. However, many developers now only write apps with higher minimum SDKs meaning that this is a non-issue.
 
 
 ## Impact on existing code
@@ -31,4 +33,4 @@ Change the min SDK in the `build.gradle` file.
 
 ## Alternatives considered
 
-Raising the min SDK to a number higher than 8 but less than 19 was considered. However, distribution on those versions are on average less than 1% of the entire Android ecosystem. SDK 19 is generally regarded as a comfortable minimum SDK.
+Raising the min SDK to a number higher than 8 but less than 16 was considered. However, distribution on those versions are on average less than 0.5% of the entire Android ecosystem.


### PR DESCRIPTION
With the progression of SDL Android as a library, it has become necessary to update the minimum supported SDK from 8. The proposed minimum SDK will be API 16, Jelly Bean.
