### PR TITLE
Revise SDL-0099 - New remote control modules

### DIFF
--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0099](0099-new-remote-control-modules-and-parameters.md)
 * Author: [Zhimin Yang](https://github.com/yang1070)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Android / RPC ]
+* Impacted Platforms: [Core / iOS / Android / RPC]
 
 ## Introduction
 
@@ -201,15 +201,6 @@ Add new a parameter to RADIO.
     </param>
   </struct>
 
-  <struct name="GPSLocation">
-    <param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180" mandatory="true">
-    </param>
-    <param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90" mandatory="true">
-    </param>
-    <param name="altitudeMeters" type="Float" minvalue="-99999" maxvalue="99999" mandatory="false">
-    </param>
-  </struct>
-
   <struct name="SisData">
     <param name="stationShortName" type="String" minlength="4" maxlength="7"  mandatory="false">
       <description>Identifies the 4-alpha-character station call sign plus an optional (-FM) extension</description>
@@ -220,7 +211,7 @@ Add new a parameter to RADIO.
     <param name="stationLongName" type="String" minlength="0" maxlength="56"  mandatory="false">
       <description>Identifies the station call sign or other identifying information in the long format.</description>
     </param>
-    <param name="stationLocation" type="GPSLocation" mandatory="false">
+    <param name="stationLocation" type="GPSData" mandatory="false">
       <description>Provides the 3-dimensional geographic station location.</description>
     </param>
     <param name="stationMessage" type="String" minlength="0" maxlength="56"  mandatory="false">

--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -368,12 +368,6 @@ New LIGHT data types.
     <element name="ON"/>
     <element name="OFF"/>
   </enum>
-  
-  <struct name="SRGBColor">
-    <param name="red" type="Integer" minvalue="0" maxvalue="255"  mandatory="true"/>
-    <param name="green" type="Integer" minvalue="0" maxvalue="255"  mandatory="true"/>
-    <param name="blue" type="Integer" minvalue="0" maxvalue="255"  mandatory="true"/>
-  </struct>
 
   <struct name="LightCapabilities">
     <param name="name" type="LightName" mandatory="true" />
@@ -383,7 +377,7 @@ New LIGHT data types.
         Indicates if the light's density can be set remotely (similar to a dimmer).
       </description>
     </param>
-    <param name="sRGBColorSpaceAvailable" type="Boolean" mandatory="false">
+    <param name="RGBColorSpaceAvailable" type="Boolean" mandatory="false">
       <description>
         Indicates if the light's color can be set remotely by using the sRGB color space.
       </description>
@@ -408,7 +402,7 @@ New LIGHT data types.
     </param>
     <param name="status" type="LightStatus" mandatory="true"/>
     <param name="density" type="Float" minvalue="0" maxvalue="1" mandatory="false" />
-    <param name="sRGBColor" type="SRGBColor" mandatory="false" />      
+    <param name="color" type="RGBColor" mandatory="false" />      
   </struct>
     
   <struct name="LightControlData">


### PR DESCRIPTION
## Introduction

Remove `GPSLocation` struct and reuse `GPSData`, which as of [SDL-0175](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0175-Updating-DOP-value-range-for-GPS-notification.md) supports optional parameters. Additionally, remove `sRGBColor` struct and reuse `RGBColor` from [SDL-0147](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0147-template-color-scheme.md).

## Motivation

The existing proposal adds duplicate structs.

## Proposed solution

Remove the duplicate structs and reuse `GPSData` and `RGBColor`.

## Potential downsides

None the author could identify.

## Impact on existing code

There will be less duplicated code.

## Alternatives considered

No alternatives were considered.