### PR TITLE
Revisions for 0188-get-interior-data-resumption.md

### DIFF
--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -48,7 +48,7 @@ Interior vehicle data resumption error handling should follow the same rules as 
 
 ## SetInteriorVehicleData behaviour changes: 
 
-If mobile send `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
+If mobile application send `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
 
 ## Potential downsides
 

--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -47,7 +47,8 @@ In the case that after reverting the subscription, there is no application subsc
 Interior vehicle data resumption error handling should follow the same rules as regular vehicle data resumption error handling. 
 
 ## SetInteriorVehicleData behaviour changes: 
-In case if mobile send `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
+
+If mobile send `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
 
 ## Potential downsides
 

--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -46,6 +46,9 @@ Reverting subscriptions means internally removing information about this subscri
 In the case that after reverting the subscription, there is no application subscribed to a certain module type, SDL should send `GetInteriorData(IsSubscribe=false)` to HMI and clear cache for this module type.
 Interior vehicle data resumption error handling should follow the same rules as regular vehicle data resumption error handling. 
 
+## SetInteriorVehicleData behaviour changes: 
+In case if mobile send `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
+
 ## Potential downsides
 
 N/A

--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -46,9 +46,9 @@ Reverting subscriptions means internally removing information about this subscri
 In the case that after reverting the subscription, there is no application subscribed to a certain module type, SDL should send `GetInteriorData(IsSubscribe=false)` to HMI and clear cache for this module type.
 Interior vehicle data resumption error handling should follow the same rules as regular vehicle data resumption error handling. 
 
-## SetInteriorVehicleData behaviour changes: 
+## SetInteriorVehicleData behavior changes:
 
-If mobile application send `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
+If a mobile application sends `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
 
 ## Potential downsides
 

--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -22,10 +22,14 @@ Interior vehicle data subscriptions should be added to resumption data.
 SDL should update hash of resumption data after application was subscribed or unsubscribed to interior vehicle data and send `OnHashUpdate` notification to mobile application.
 
 In case application was unexpectedly disconnected or SDL was stopped when application was registered,
-SDL should save application subscriptions internally and keep them for 3 (configured by ini file) ignition cycles.
+SDL should save application subscriptions internally and keep them for 3 ignition cycles.
 
 If correct hash was provided by the next application registration, interior vehicle data subscription should be restored.
 All existing resumption rules should be applied for Interior vehicle data resumption.
+
+Documentation has to be added to hashID in registerAppInterface in the RPC spec including the MOBILE_API.xml file in Core.
+Hash ID Resumption information should be added to the Best Practices guide.
+
 
 #### Restoring Interior vehicle data
 


### PR DESCRIPTION
Revisions for #554
Signed-off-by: Alexander <akutsan@luxoft.com>

Added information in the proposal that documentation should be updated with hash id management. 

Removed information that count of ignition cycles configured by ini file ( this value is hardcoded in SDL) 