### PR TITLE
Revise SDL-0175 - Updating DOP value range for GPS notification

### DIFF
--- a/proposals/0175-Updating-DOP-value-range-for-GPS-notification.md
+++ b/proposals/0175-Updating-DOP-value-range-for-GPS-notification.md
@@ -18,14 +18,14 @@ Current range for vdop/hdop/pdop values is 0-10. GPS sensor can provide DOP valu
 To increase the maxvalue for vdop, pdop and hdop parameters to 1000 from 10 in GetVehicleData response and onVehicleData notification. Since DOP cannot reach that high value, this will ensure that gps notifications are NOT filtered out due to DOP.
 And to make the hdop, pdop, vdop fields non mandatory for both HMI and Mobile APIs so that SDL allows the GPS notification without these params as well in case GPS sensor omits these parameters.
 
-**Proposed Mobile API changes:**
+**Proposed Mobile and HMI API changes:**
 ```
   <struct name="GPSData">
     <description>Struct with the GPS data.</description>
-	<param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180">
-	</param>
-	<param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90">
-	</param>
+    <param name="longitudeDegrees" type="Float" minvalue="-180" maxvalue="180" mandatory="true">
+    </param>
+    <param name="latitudeDegrees" type="Float" minvalue="-90" maxvalue="90" mandatory="true">
+    </param>
     <param name="utcYear" type="Integer" minvalue="2010" maxvalue="2100" mandatory="false">
     	<description>The current UTC year.</description>
     </param>
@@ -88,13 +88,6 @@ And to make the hdop, pdop, vdop fields non mandatory for both HMI and Mobile AP
     </param>
     <param name="speed" type="Float" minvalue="0" maxvalue="500" mandatory="false">
     	<description>The speed in KPH</description>
-    </param>
-    <param name="shifted" type="Boolean" mandatory="false">
-    	<description>
-    		True, if GPS lat/long, time, and altitude have been purposefully shifted (requiring a proprietary algorithm to unshift).
-    		False, if the GPS data is raw and un-shifted.
-    		If not provided, then value is assumed False.
-    	</description>
     </param>
   </struct>
 

--- a/proposals/0175-Updating-DOP-value-range-for-GPS-notification.md
+++ b/proposals/0175-Updating-DOP-value-range-for-GPS-notification.md
@@ -18,6 +18,8 @@ Current range for vdop/hdop/pdop values is 0-10. GPS sensor can provide DOP valu
 To increase the maxvalue for vdop, pdop and hdop parameters to 1000 from 10 in GetVehicleData response and onVehicleData notification. Since DOP cannot reach that high value, this will ensure that gps notifications are NOT filtered out due to DOP.
 And to make the hdop, pdop, vdop fields non mandatory for both HMI and Mobile APIs so that SDL allows the GPS notification without these params as well in case GPS sensor omits these parameters.
 
+This proposal also keeps parameter `longitudeDegrees` and `latitudeDegrees` as mandatory but the rest of the parameters in `GPSData` being switched to optional.
+
 **Proposed Mobile and HMI API changes:**
 ```
   <struct name="GPSData">


### PR DESCRIPTION
# Introduction
Proposal [SDL-0175]( https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0175-Updating-DOP-value-range-for-GPS-notification.md) has two issues:
1. It shall not include the `shifted` parameter, as `shifted` is not relevant to this proposal.
2. It does not include the mandatory attribute  `mandatory` for parameters `longitudeDegrees` and  `latitudeDegrees`. So it is ambiguous whether the parameters `longitudeDegrees` and  `latitudeDegrees` shall be mandatory or not. 

# Motivation
Fix the issues.

# Proposed solution
Remove `shifted` parameter from  GPSData.
Since it does not make sense if a `GPSData` does not include the parameter `longitudeDegrees` or   the parameter `latitudeDegrees`, we shall mark  `mandatory=true` for both parameters in both mobile api and hmi api.


# Potential downsides
None the author could identify.

# Impact on existing code
RPC (mobile_api and hmi_api)  spec shall be updated.
Mobile proxy shall remove parameter presence check if there is any.
Update https://github.com/smartdevicelink/sdl_core/pull/2417/ 
Since this is an update to the accepted but not released proposal, the impact shall be minimum.

# Alternatives considered
No alternatives were considered.