### PR TITLE
Revise SDL-0153 Support for Short and Full UUID App ID

### DIFF
--- a/proposals/0153-support-short-long-appid.md
+++ b/proposals/0153-support-short-long-appid.md
@@ -21,7 +21,7 @@ Add a new variable to RegisterAppInterface request:
 
 | Value |  Type | Mandatory | Description | 
 | ---------- | ---------- |:-----------: |:-----------:|
-|`fullAppID`|String|True|ID used to validate app with policy table entries|
+|`fullAppID`|String|False|ID used to validate app with policy table entries|
 
 When an app registers with [smartdevicelink.com](https://www.smartdevicelink.com), it is assigned an "appID" and a "fullAppID". The "fullAppID" will be the full UUID appID SHAID is currently generating. The "appID" string will be the first 10 non "-" characters of the full "fullAppID".  
 
@@ -38,6 +38,8 @@ If only the (short) appID is present in the RegisterAppInterface RPC request (le
 If both the (short) appID and the (long) fullAppID are in the RegisterAppInterface RPC request (updated apps), sdl core shall ignore the (short) appID and use the (long) fullAppID as the internal policy app id. i.e. use fullAppID as the policy_app_id and use it to construct the icon path.
 
 For ease of use, the mobile libraries will be updated to automatically create the (short) appID based on the first 10 non "-" characters of the "fullAppID" -- this will ensure apps continue to be backwards compatible with existing OEM implementations (without requiring extra work from mobile app developer standpoints). 
+
+Note: AppIDs in SDL Core are not case sensitive. Forcing AppIds to lowercase has been a legacy behavior in Core so SHAID must also force AppIds to lowercase. 
 
 ## Potential downsides
 


### PR DESCRIPTION
## Introduction
This is a revision to make fullAppID mandatory="false" and to add a clarifying note regarding appID case insensitivity.

## Motivation

#### Make Full App ID Non Mandatory
There is language in the original proposal conflicting with the fullAppID RPC spec definition.

From proposal:
> If only the (short) appID is present in the RegisterAppInterface RPC request (legacy apps), sdl core shall use the (short) appID as the internal policy app id. i.e. use appID as the policy_app_id and use it to construct the icon path.

In order for this case to be possible, fullAppID must be non mandatory. In addition, even with mobile version negotiation, making fullAppID mandatory would cause a breaking change in RegisterAppInterfaceRequest for legacy applications.


#### Include Note Regarding AppID Case Insensitivity
During the Core implementation of this original proposal, it was discovered that there was an existing behavior in Core that converts incoming appIDs from a RegisterAppInterfaceRequest to lowercase. I am adding this note to the proposal for documentation and visibility purposes. 

## Proposed solution

Change fullAppID rpc spec signature to: 

| Value |  Type | Mandatory | Description | 
| ---------- | ---------- |:-----------: |:-----------:|
|`fullAppID`|String|False|ID used to validate app with policy table entries|

## Potential downsides
None the author could identify.

## Impact on existing code
Change mandatory value `fullAppID` in mobile_api.xml in RPC Spec to false.

## Alternatives considered
No alternatives were considered.
