### PR TITLE
Revise SDL-0122 to exclude synonyms

### DIFF
--- a/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
+++ b/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
@@ -17,7 +17,7 @@ The `vrHelp` parameter of the `SetGlobalProperties` RPC is used by the system to
 
 The proposed mechanism is detailed below:
 1. If the application sends any `AddCommand` with the `vrCommands` parameter then SDL Core shall maintain a list of the added `vrCommands`.
-__For each `AddCommand`, only the first item in the `vrCommands` array shall be added to the list.__
+For each `AddCommand`, only the first item in the `vrCommands` array shall be added to the list.
 2. If the application sends any `DeleteCommand` requests then SDL Core shall remove the added `vrCommands` from its list.
 3. Whenever this internal list of added `vrCommands` is updated, SDL Core shall:
 	1. construct the `vrHelp` parameter using the data from the list SDL Core internally created.

--- a/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
+++ b/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md
@@ -17,6 +17,7 @@ The `vrHelp` parameter of the `SetGlobalProperties` RPC is used by the system to
 
 The proposed mechanism is detailed below:
 1. If the application sends any `AddCommand` with the `vrCommands` parameter then SDL Core shall maintain a list of the added `vrCommands`.
+__For each `AddCommand`, only the first item in the `vrCommands` array shall be added to the list.__
 2. If the application sends any `DeleteCommand` requests then SDL Core shall remove the added `vrCommands` from its list.
 3. Whenever this internal list of added `vrCommands` is updated, SDL Core shall:
 	1. construct the `vrHelp` parameter using the data from the list SDL Core internally created.


### PR DESCRIPTION
# Revise SDL-0122 to exclude synonyms

 * Altered Proposal [SDL-0122 Handling VR help requests when application does not send VR help prompt](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0122-New_rules_for_providing_VRHelpItems_VRHelpTitle.md) 
 * Author: [Robin Kurian](https://github.ford.com/RKURIAN1)
 * Status: Awaiting Review
 * Impacted Platforms: [Core]
## Introduction
SDL-0122 introduced an un-intended behavior where if an app sends multiple values for the `vrCommands` parameter for an `AddCommand` then those values would fill up the Help Menu and Help Prompt. The original intention was to provide a backup for the user's to be aware of the different help prompts supported by the application if the application does not set its help prompt via the `SetGlobalProperties` RPC and for that only one `vrCommand` per `AddCommand` would suffice.

## Motivation
Certain apps send multiple `vrCommand` synonyms for a single `AddCommand` causing the Help Menu and Help Prompt to fill up with a few options. This proposal proposes mechanism to over come this un-intended behavior.

## Proposed solution
When SDL Core creates a list of `vrCommands` for each `AddCommand`, use only the first element from the array of `vrCommands` sent by the application. 
The change to the original proposal is highlighted in __bold__.

## Potential downsides
N/A

## Impact on existing code
Update code to only add the first element from the array of `vrCommands` to the list SDL maintains for sending `SetGlobalProperties` to HMI.

## Alternatives considered
None
