### PR TITLE
Revise SDL-0099 `rgbColorSpaceAvailable`

### DIFF
--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -377,7 +377,7 @@ New LIGHT data types.
         Indicates if the light's density can be set remotely (similar to a dimmer).
       </description>
     </param>
-    <param name="RGBColorSpaceAvailable" type="Boolean" mandatory="false">
+    <param name="rgbColorSpaceAvailable" type="Boolean" mandatory="false">
       <description>
         Indicates if the light's color can be set remotely by using the sRGB color space.
       </description>


### PR DESCRIPTION
## Introduction

Renames `RGBColorSpaceAvailable` to `rgbColorSpaceAvailable`.

## Motivation

This parameter breaks the naming scheme for parameters in the spec, this revision fixes that.

## Proposed solution

Rename `RGBColorSpaceAvailable` to `rgbColorSpaceAvailable`.

## Potential downsides

N/A

## Impact on existing code

N/A

## Alternatives considered

N/A