### PR TITLE
Revise SDL-0099 - Add a keepContextAvailable parameter and fix typos

### DIFF
--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -241,7 +241,7 @@ New AUDIO data types.
       <description>Availability of the control of audio source. </description>
     </param>
     <param name="keepContextAvailable" type="Boolean" mandatory="false"> 
-      <description>Availability of the keepContext paramter. </description> 
+      <description>Availability of the keepContext parameter. </description> 
     </param>
     <param name="volumeAvailable" type="Boolean" mandatory="false">
       <description>Availability of the control of audio volume.</description>

--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -240,6 +240,9 @@ New AUDIO data types.
     <param name="sourceAvailable" type="Boolean" mandatory="false">
       <description>Availability of the control of audio source. </description>
     </param>
+    <param name="keepContextAvailable" type="Boolean" mandatory="false"> 
+      <description>Availability of the keepContext paramter. </description> 
+    </param>
     <param name="volumeAvailable" type="Boolean" mandatory="false">
       <description>Availability of the control of audio volume.</description>
     </param>
@@ -273,9 +276,10 @@ New AUDIO data types.
     <param name="keepContext" type="Boolean" mandatory="false">
       <description>
       This parameter shall not be present in any getter responses or notifications.
-      This parameter is optional in a setter request. The default value is false.
-      If it is true, the system not only changes the audio source but also brings the default infotainment system UI associated with the audio source to foreground and set the application to background.
-      If it is false, the system changes the audio source, but keeps the current application's context.
+      This parameter is optional in a setter request. The default value is false if it is not included.
+      If it is false, the system not only changes the audio source but also brings the default application or
+      system UI associated with the audio source to foreground.
+      If it is true, the system only changes the audio source, but keeps the current application in foreground.
       </description>
     </param>
     <param name="volume" type="Integer" mandatory="false" minvalue="0" maxvalue="100">

--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -273,7 +273,7 @@ New AUDIO data types.
       If the value is MOBILE_APP, the system shall switch to the mobile media app that issues the setter RPC.
       </description>
     </param>
-    <param name="keepContext" type="Boolean" mandatory="false">
+    <param name="keepContext" type="Boolean" defvalue="false" mandatory="false">
       <description>
       This parameter shall not be present in any getter responses or notifications.
       This parameter is optional in a setter request. The default value is false if it is not included.


### PR DESCRIPTION
# Introduction
Proposal [SDL-0099]( https://github.com/yang1070/sdl_evolution/blob/master/proposals/0099-new-remote-control-modules-and-parameters.md) has some issues:
1. Parameter `keepContextAvailable` is missing in the `AudioControlCapabilities`. It is used to tell the mobile applications that the vehicle can support parameter `keepContext` or not.  Usually, for each controllable parameter, there is an available parameter in the capabilities. And `keepContextAvailable` is missing.
2. It has some typos in the description of parameter `keepContext`.

# Motivation
Fix the issues.

# Proposed solution
Add a new `keepContextAvailable` parameter to `AudioControlCapabilities`.
Update the description of parameter `keepContext`.


# Potential downsides
None the author could identify.

# Impact on existing code
RPC (mobile_api and hmi_api)  spec shall be updated.
Android and iOS implementations will also need to be updated to include this new parameter.
Since this is an update to the accepted but not released proposal, the impact shall be minimum.

# Alternatives considered
No alternatives were considered.