### PR TITLE
Remove defvalue from keepContext

### DIFF
--- a/proposals/0099-new-remote-control-modules-and-parameters.md
+++ b/proposals/0099-new-remote-control-modules-and-parameters.md
@@ -273,7 +273,7 @@ New AUDIO data types.
       If the value is MOBILE_APP, the system shall switch to the mobile media app that issues the setter RPC.
       </description>
     </param>
-    <param name="keepContext" type="Boolean" defvalue="false" mandatory="false">
+    <param name="keepContext" type="Boolean" mandatory="false">
       <description>
       This parameter shall not be present in any getter responses or notifications.
       This parameter is optional in a setter request. The default value is false if it is not included.


### PR DESCRIPTION
# Introduction
Recent revisions made to proposal [SDL-0099]( https://github.com/yang1070/sdl_evolution/blob/master/proposals/0099-new-remote-control-modules-and-parameters.md) has one issue. Parameter `keepContext` should not have a `defvalue` defined in the parameter line because `keepContext` should not appear in every RPC where `AudioControlData` is used.

By setting a default value for `keepContext` in the mobile_api.xml, `keepContext` was appearing in the OnInteriorVehicleData and GetInteriorVehicleData RPCs. The parameter `keepContext` only makes sense in the context of SetInteriorVehicleData.



# Motivation
Fix the unintended issues caused by recent revision to proposal.

# Proposed solution
Remove `defvalue` from the `keepContext` parameter line in the mobile_api.xml.


# Potential downsides
None the author could identify.

# Impact on existing code
RPC Spec should be updated.

# Alternatives considered
No alternatives were considered.