### PR TITLE
Revise SDL-0071 - remove default value for parameter subscribe in RPC GetInteriorVehicleData

### DIFF
--- a/proposals/0071-remote-control-baseline.md
+++ b/proposals/0071-remote-control-baseline.md
@@ -699,10 +699,11 @@ The changes are listed below.
         In the future, this should be the Identification of a module.
       </description>
     </param>
-    <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
+    <param name="subscribe" type="Boolean" mandatory="false">
       <description>
         If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
         If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
+        If subscribe is not included, the subscription status of the app for the requested moduelType will remain unchanged.
       </description>
     </param>
   </function>
@@ -1190,8 +1191,12 @@ The changes are similar to mobile api changes, they are  listed here.
     <param name="moduleType" type="Common.ModuleType">
       <description>The module data to retrieve from the vehicle for that type</description>
     </param>
-    <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
-      <description>If subscribe is true, the head unit will send onInteriorVehicleData notifications for the module type</description>
+    <param name="subscribe" type="Boolean" mandatory="false">
+      <description>
+        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
+        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
+        If subscribe is not included, the subscription status of the app for the requested moduelType will remain unchanged.
+      </description>
     </param>
     <param name="appID" type="Integer" mandatory="true">
       <description>Internal SDL-assigned ID of the related application</description>

--- a/proposals/0071-remote-control-baseline.md
+++ b/proposals/0071-remote-control-baseline.md
@@ -135,10 +135,11 @@ The system shall list all available RC radio buttons and RC climate buttons in t
         In the future, this should be the Identification of a module.
       </description>
     </param>
-    <param name="subscribe" type="Boolean" mandatory="false" defvalue="false">
+    <param name="subscribe" type="Boolean" mandatory="false">
       <description>
         If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
         If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
+        If subscribe is not included, the subscription status of the app for the requested moduelType will remain unchanged.
       </description>
     </param>
   </function>

--- a/proposals/0071-remote-control-baseline.md
+++ b/proposals/0071-remote-control-baseline.md
@@ -1195,7 +1195,7 @@ The changes are similar to mobile api changes, they are  listed here.
       <description>
         If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
         If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is not included, the subscription status of the app for the requested moduelType will remain unchanged.
+        If subscribe is not included, the subscription status for the requested moduelType will remain unchanged.
       </description>
     </param>
     <param name="appID" type="Integer" mandatory="true">

--- a/proposals/0071-remote-control-baseline.md
+++ b/proposals/0071-remote-control-baseline.md
@@ -137,9 +137,9 @@ The system shall list all available RC radio buttons and RC climate buttons in t
     </param>
     <param name="subscribe" type="Boolean" mandatory="false">
       <description>
-        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is not included, the subscription status of the app for the requested moduelType will remain unchanged.
+        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduleType.
+        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduleType.
+        If subscribe is not included, the subscription status of the app for the requested moduleType will remain unchanged.
       </description>
     </param>
   </function>
@@ -702,9 +702,9 @@ The changes are listed below.
     </param>
     <param name="subscribe" type="Boolean" mandatory="false">
       <description>
-        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is not included, the subscription status of the app for the requested moduelType will remain unchanged.
+        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduleType.
+        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduleType.
+        If subscribe is not included, the subscription status of the app for the requested moduleType will remain unchanged.
       </description>
     </param>
   </function>
@@ -1194,9 +1194,9 @@ The changes are similar to mobile api changes, they are  listed here.
     </param>
     <param name="subscribe" type="Boolean" mandatory="false">
       <description>
-        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduelType.
-        If subscribe is not included, the subscription status for the requested moduelType will remain unchanged.
+        If subscribe is true, the head unit will register onInteriorVehicleData notifications for the requested moduleType.
+        If subscribe is false, the head unit will unregister onInteriorVehicleData notifications for the requested moduleType.
+        If subscribe is not included, the subscription status for the requested moduleType will remain unchanged.
       </description>
     </param>
     <param name="appID" type="Integer" mandatory="true">


### PR DESCRIPTION
# Introduction

The xml interface of RPC `GetInteriorVehicleData` does not match the description in proposal [SDL-0071](https://github.com/yang1070/sdl_evolution/blob/master/proposals/0071-remote-control-baseline.md).

The proposal  [SDL-0071](https://github.com/yang1070/sdl_evolution/blob/master/proposals/0071-remote-control-baseline.md) clearly called out 3 related APIs shall be provided
- API to read RC module status data.
- API to subscribe RC module status/setting change notifications.
- API to unsubscribe RC module status/setting change notifications.

However, the xml spec has `defvalue="false"` for the parameter `subscribe` in RPC `GetInteriorVehicleData`.   Setting a default value to false means if the parameter `subscribe`  is not provided in the RPC call, SDL shall treat it as `false` and perform a un-subscribe action. Thus, it has the side effect to eliminate the first API, which is to read RC module status data only without changing the subscription status.

# Motivation
Fix the issues.

# Proposed solution

Remove  `defvalue="false"` in both mobile and hmi api and update parameter description.
 ```xml
<param name="subscribe" type="Boolean" mandatory="false" >
```

# Potential downsides
The developers currently using this unintended behavior as the correct behavior will have their implementations break/change. For example, if a developer assumed they could just send a GetInteriorVehicleData without the subscribe parameter to unsubscribe from the module, their app would actually remain subscribed which means they would receive OnInteriorVehicleData updates.

# Impact on existing code

The defValue inclusion created unintended behavior from inception. This means that the 4.5 spec would require a hotfix to remove the defValue tag and update the description. In the 5.0 RPC spec we will add the history tag for the 4.5 to 4.5.1 change. This would require the Core releases to be updated that used the 4.5 spec. This obviously takes a bit of effort, but makes the most sense.

RPC (mobile_api and hmi_api)  spec shall be updated.
Android and iOS implementations will also need to be updated to remove the behavior of the default value of this parameter.

# Alternatives considered
No alternatives were considered by the author.
