### PR TITLE
Avoid Custom button subscription in case HMI incompatibility

### DIFF
--- a/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -18,7 +18,7 @@ SDL should check hmi_capabilities and subscribe application to `CUSTOM_BUTTON` i
 
 ## Proposed solution
 
-SDL should check hmi_capabilities for `CUSTOM_BUTTON` by the start and save the support state for `CUSTOM_BUTTON` internally.
+SDL should check hmi_capabilities for `CUSTOM_BUTTON` by the start and save support state for `CUSTOM_BUTTON` internally.
 On the app registration, SDL should check the saved support state for `CUSTOM_BUTTON`.
 
 In case `CUSTOM_BUTTON` is supported by hmi_capabilities:

--- a/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -1,0 +1,74 @@
+
+# Avoid Custom button subscription in case HMI incompatibility
+
+* Proposal: [SDL-NNNN](NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md)
+* Author: [Getmanets Irina](https://github.com/GetmanetsIrina)
+* Status: **Awaiting review**
+* Impacted Platforms: [Core]
+
+## Introduction
+
+In case HMI does not support `CUSTOM_BUTTON`, SDL should not try to subscribe application to it.
+
+## Motivation
+
+Now SDL does not check hmi_capabilities before subscription to `CUSTOM_BUTTON`. So it will try to subscribe each registered application to `CUSTOM_BUTTON` even if it is unsupported by HMI.
+
+SDL should check hmi capabilities and subscribe application to `CUSTOM_BUTTON` if it is **supported by HMI only**.
+
+## Proposed solution
+
+On application registration SDL should check hmi capabilities.
+
+In case `CUSTOM_BUTTON` is supported by hmi_capabilities :
+SDL should send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI and wait for response.
+
+
+In case `CUSTOM_BUTTON` is not supported by hmi_capabilities :
+SDL should **not** send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI.
+
+If HMI supports `CUSTOM_BUTTON` it should be in `Buttons[capabilities]` section of `hmi_capabilities.json` :
+
+```
+"Buttons": {
+       "capabilities": [
+        ...,
+        {
+               "name": "CUSTOM_BUTTON",
+               "shortPressAvailable": true,
+               "longPressAvailable": true,
+               "upDownAvailable": true
+           }
+        ]
+}
+```
+
+
+If HMI supports `CUSTOM_BUTTON`, response to `Buttons.GetCapabilities` should contain following structure :
+
+```
+"capabilities": [
+        ...,
+        {
+               "name": "CUSTOM_BUTTON",
+               "shortPressAvailable": true,
+               "longPressAvailable": true,
+               "upDownAvailable": true
+           }
+        ]
+```
+
+
+`Buttons.GetCapabilities` request has higher priority than `hmi_capabilities.json`.
+
+## Potential downsides
+
+N/A
+
+## Impact on existing code
+
+* SDL core needs to be updated
+
+## Alternatives considered
+
+N/A

--- a/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -18,7 +18,8 @@ SDL should check hmi_capabilities and subscribe application to `CUSTOM_BUTTON` i
 
 ## Proposed solution
 
-On the application registration, SDL should check hmi_capabilities.
+SDL should check hmi_capabilities for `CUSTOM_BUTTON` by the start and save the support state for `CUSTOM_BUTTON` internally.
+On the app registration, SDL should check the saved support state for `CUSTOM_BUTTON`.
 
 In case `CUSTOM_BUTTON` is supported by hmi_capabilities:
 SDL should send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI and wait for a response.

--- a/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -14,20 +14,20 @@ In case HMI does not support `CUSTOM_BUTTON`, SDL should not try to subscribe ap
 
 Now SDL does not check hmi_capabilities before subscription to `CUSTOM_BUTTON`. So it will try to subscribe each registered application to `CUSTOM_BUTTON` even if it is unsupported by HMI.
 
-SDL should check hmi capabilities and subscribe application to `CUSTOM_BUTTON` if it is **supported by HMI only**.
+SDL should check hmi_capabilities and subscribe application to `CUSTOM_BUTTON` if it is **supported by HMI only**.
 
 ## Proposed solution
 
-On application registration SDL should check hmi capabilities.
+On application registration SDL should check hmi_capabilities.
 
-In case `CUSTOM_BUTTON` is supported by hmi_capabilities :
+In case `CUSTOM_BUTTON` is supported by hmi_capabilities:
 SDL should send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI and wait for response.
 
 
-In case `CUSTOM_BUTTON` is not supported by hmi_capabilities :
+In case `CUSTOM_BUTTON` is not supported by hmi_capabilities:
 SDL should **not** send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI.
 
-If HMI supports `CUSTOM_BUTTON` it should be in `Buttons[capabilities]` section of `hmi_capabilities.json` :
+If HMI supports `CUSTOM_BUTTON` it should be in `Buttons[capabilities]` section of `hmi_capabilities.json`:
 
 ```
 "Buttons": {
@@ -44,7 +44,7 @@ If HMI supports `CUSTOM_BUTTON` it should be in `Buttons[capabilities]` section 
 ```
 
 
-If HMI supports `CUSTOM_BUTTON`, response to `Buttons.GetCapabilities` should contain following structure :
+If HMI supports `CUSTOM_BUTTON`, response to `Buttons.GetCapabilities` should contain following structure:
 
 ```
 "capabilities": [
@@ -67,7 +67,7 @@ N/A
 
 ## Impact on existing code
 
-* SDL core needs to be updated
+SDL core needs to be updated.
 
 ## Alternatives considered
 

--- a/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/NNNN-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -8,26 +8,26 @@
 
 ## Introduction
 
-In case HMI does not support `CUSTOM_BUTTON`, SDL should not try to subscribe application to it.
+In case HMI does not support `CUSTOM_BUTTON`, SDL should not try to subscribe an application to it.
 
 ## Motivation
 
-Now SDL does not check hmi_capabilities before subscription to `CUSTOM_BUTTON`. So it will try to subscribe each registered application to `CUSTOM_BUTTON` even if it is unsupported by HMI.
+SDL does not check hmi_capabilities before subscription to `CUSTOM_BUTTON`, so it tries to subscribe each registered application to `CUSTOM_BUTTON` even if it is unsupported by HMI.
 
 SDL should check hmi_capabilities and subscribe application to `CUSTOM_BUTTON` if it is **supported by HMI only**.
 
 ## Proposed solution
 
-On application registration SDL should check hmi_capabilities.
+On the application registration, SDL should check hmi_capabilities.
 
 In case `CUSTOM_BUTTON` is supported by hmi_capabilities:
-SDL should send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI and wait for response.
+SDL should send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI and wait for a response.
 
 
 In case `CUSTOM_BUTTON` is not supported by hmi_capabilities:
 SDL should **not** send `Buttons.SubscribeButtons(CUSTOM_BUTTON)` to HMI.
 
-If HMI supports `CUSTOM_BUTTON` it should be in `Buttons[capabilities]` section of `hmi_capabilities.json`:
+If HMI supports `CUSTOM_BUTTON`, it should be in the `Buttons[capabilities]` section of `hmi_capabilities.json`:
 
 ```
 "Buttons": {
@@ -67,7 +67,7 @@ N/A
 
 ## Impact on existing code
 
-SDL core needs to be updated.
+SDL core will need to be updated.
 
 ## Alternatives considered
 


### PR DESCRIPTION
In case if HMI does not support `CUSTOM_BUTTON`, SDL should not try to subscribe application to it.