### PR TITLE
 Avoid Custom button subscription in case HMI incompatibility (revision)

### DIFF
--- a/proposals/0205-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/0205-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -62,6 +62,8 @@ If HMI supports `CUSTOM_BUTTON`, response to `Buttons.GetCapabilities` should co
 
 `Buttons.GetCapabilities` request has higher priority than `hmi_capabilities.json`.
 
+Existing rules for applying HMI capabilities won't be changed. If mobile application sends `SubscribeButton (buttonName = CUSTOM_BUTTON)` and `CUSTOM_BUTTON` is not supported by HMI (absent in the `hmi_capabilities.json`), SDL will respond with `UNSUPPORTED_RESOURCE` result code.
+
 ## Potential downsides
 
 N/A

--- a/proposals/0205-Avoid_custom_button_subscription_when_HMI_does_not_support.md
+++ b/proposals/0205-Avoid_custom_button_subscription_when_HMI_does_not_support.md
@@ -62,7 +62,7 @@ If HMI supports `CUSTOM_BUTTON`, response to `Buttons.GetCapabilities` should co
 
 `Buttons.GetCapabilities` request has higher priority than `hmi_capabilities.json`.
 
-Existing rules for applying HMI capabilities won't be changed. If mobile application sends `SubscribeButton (buttonName = CUSTOM_BUTTON)` and `CUSTOM_BUTTON` is not supported by HMI (absent in the `hmi_capabilities.json`), SDL will respond with `UNSUPPORTED_RESOURCE` result code.
+The existing rules for applying HMI capabilities won't be changed. If a mobile application sends `SubscribeButton (buttonName = CUSTOM_BUTTON)` and `CUSTOM_BUTTON` and they are not supported by HMI (absent in the `hmi_capabilities.json`), then SDL will respond with an `UNSUPPORTED_RESOURCE` result code.
 
 ## Potential downsides
 


### PR DESCRIPTION
This PR includes requested changes  for proposal [0205](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0205-Avoid_custom_button_subscription_when_HMI_does_not_support.md). Proposal and required changes to it were discussed during Steering Committee meeting at 12/11/18.

This revision includes adding `UNSUPPORTED_RESOURCE` response in case then a `CUSTOM_BUTTON` is not supported as noted in [comment](https://github.com/smartdevicelink/sdl_evolution/issues/632#issuecomment-446365125)

No other changes where requested to this proposal.