### PR TITLE
Remote Control - Radio and Climate Parameter Update (Accepted revisions for SDL-0213)

### DIFF
--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-Currently, SDL only tells an application the total number of HD channels that are available for a given frequency via parameter `availableHDs` in `RadioControlData`. The application knows the maximum HD channel index is 7. However, it does not know exactly which HD sub-channel index has a valid broadcasting signal. This proposal adds a new read-only parameter `availableHdChannels`, which is a list of HD sub-channel indexes with HD radio broadcasting, to `RadioControlData` data structure. This proposal also adds a new parameter `availableHdChannelsAvailable` to `RadioControlCapabilities` data structure to indicate whether the vehicle supports the new parameter `availableHdChannels`.
+Currently, SDL only tells an application the total number of HD channels that are available for a given frequency via parameter `availableHDs` in `RadioControlData`. The application knows the maximum HD channel index is 7. However, it does not know exactly which HD sub-channel index has a valid broadcasting signal. This proposal deprecates this `availableHDs` parameter and adds a new read-only parameter `availableHdChannels`, which is a list of HD sub-channel indexes with HD radio broadcasting. This proposal also deprecates the corresponding parameter `availableHDsAvailable` and adds a new parameter `availableHdChannelsAvailable` to `RadioControlCapabilities` data structure to indicate whether the vehicle supports the new parameter `availableHdChannels`.
 
 This proposal changes the minimum index of HD radio sub-channels from 1 to 0.
 
@@ -23,9 +23,13 @@ SDL remote control shall allow a mobile application to turn the climate control 
 
 ## Proposed solution
 
+Deprecate the `availableHDs` parameter in `RadioControlData`.
+
 Add a new parameter `availableHdChannels` to `RadioControlData` to allow an application to know what HD radio channel indexes are available.
 
 Add a new parameter `climateEnable` to `ClimateControlData` to allow an application to power on or off climate control.
+
+Update `RadioControlCapabilities` and `ClimateControlCapabilities` correspondingly.
 
 In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0.
 
@@ -36,18 +40,17 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 ...
 <!-- new additions or changes -->
 -   <param name="availableHDs" type="Integer" minvalue="1 maxvalue="7" mandatory="false" since="5.0">
-+   <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
++   <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.1">
         <description>number of HD sub-channels if available</description>
         <history>
             <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-+           <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
         </history>
     </param>
-	
-+   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" mandatory="false" minsize="1" maxsize="8" array="true" since="5.1">
-+       <description>the list of hd sub-channel indexes if available, read-only </description>
+    
++   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.1">
++       <description>the list of available hd sub-channel indexes, empty list means no Hd channel is available, read-only </description>
 +   </param>
-	
+    
 -    <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
 +    <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
         <description>Current HD sub-channel if available</description>
@@ -61,6 +64,13 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 
 <struct name="RadioControlCapabilities" since="4.5">
 ...
+-    <param name="availableHDsAvailable" type="Boolean" mandatory="false">
++    <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.1">
+        <description>
+            Availability of the getting the number of available HD channels.
+            True: Available, False: Not Available, Not present: Not Available.
+        </description>
+    </param>
 +   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.1">
 +       <description>
 +           Availability of the list of available HD sub-channel indexes.
@@ -84,8 +94,9 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 </struct>
 
 <struct name="ClimateControlData" since="4.5">
+...
 +    <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
-+     </param>
++    </param>
 ...
 </struct>
 ```


### PR DESCRIPTION
Currently, SDL only tells an application the total number of HD channels that are available for a given frequency via parameter `availableHDs` in `RadioControlData`. The application knows the maximum HD channel index is 7. However, it does not know exactly which HD sub-channel index has a valid broadcasting signal. This proposal deprecates this `availableHDs` parameter and adds a new read-only parameter `availableHdChannels`, which is a list of HD sub-channel indexes with HD radio broadcasting. This proposal also deprecates the corresponding parameter `availableHDsAvailable` and adds a new parameter `availableHdChannelsAvailable` to `RadioControlCapabilities` data structure to indicate whether the vehicle supports the new parameter `availableHdChannels`.

This proposal changes the minimum index of HD radio sub-channels from 1 to 0.

In addition, we propose to add a new parameter `climateEnable` to `ClimateControlData` which will allow an application to power climate control on or off.
