### PR TITLE
Revisions to 0167-app-services

### DIFF
--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -478,11 +478,11 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 		</param>
 		
 		<param name="serviceType" type="String" mandatory="true">
-			<description>The type of service that is to be offered by this app</description>
+			<description>The type of service that is to be offered by this app. See AppServiceType</description>
 		</param>
 		
 		<param name="serviceIcon" type="Image" mandatory="false">
-			<description> The file name of the icon to be associated with this service. Most likely the same as the appIcon.</description>
+			<description> The image object be associated with this service. Most likely the same as the appIcon.</description>
 		</param>
 		
 		<param name="allowAppConsumers" type="Boolean" mandatory="false" defvalue="false">
@@ -502,7 +502,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 			<description> This is the max RPC Spec version the app service understands. This is important during the RPC passthrough functionality. If not included, it is assumed the max version of the module is acceptable. </description>
 		</param>
 		<param name="handledRPCs" type="Integer" array="true" mandatory="false">
-			<description> This field contains the Function IDs for the RPCs that this service intends to handle correctly. This means the service will provide meaningful responses. </description>
+			<description> This field contains the Function IDs for the RPCs that this service intends to handle correctly. This means the service will provide meaningful responses. See FunctionID.</description>
 		</param>
 		
 		<param name="mediaServiceManifest" type="MediaServiceManifest" mandatory="false"/>
@@ -715,7 +715,9 @@ When requesting the data from the app service the developer can expect the data 
 <struct name="AppServiceData">
 	<description> Contains all the current data of the app service. The serviceType will link to which of the service data objects are included in this object. (eg if service type equals MEDIA, the mediaServiceData param should be included.</description>
 	
-	<param name="serviceType" type="String" mandatory="true"/>
+	<param name="serviceType" type="String" mandatory="true">
+		<description>See AppServiceType</description>
+	</param>
 	<param name="serviceID" type="String" mandatory="true"/>
 		
 	<param name="mediaServiceData" type="MediaServiceData" mandatory="false"/>
@@ -741,7 +743,9 @@ The response from a `GetAppServiceData`  should include all service data that is
 <function name="GetAppServiceData" functionID="GetAppServiceDataID" messagetype="request">
 	<description> This request asks the module for current data related to the specific service. It also includes an option to subscribe to that service for future updates</description>
 	
-	<param name="serviceType" type="String" mandatory="true"/>
+	<param name="serviceType" type="String" mandatory="true">
+		<description>See AppServiceType</description>
+	</param>
 	
 	<param name="subscribe" type="Boolean" mandatory="false">
 		<description> If true, the consumer is requesting to subscribe to all future updates from the service publisher. If false, the consumer doesn't wish to subscribe and should be unsubscribed if it was previously subscribed.</description>
@@ -898,7 +902,7 @@ SDL should make no guarantees that:
 
 
 ```xml
-<element name="PerformAppServiceInteractiontFileID" value="55" hexvalue="37" since="5.1" />
+<element name="PerformAppServiceInteractionID" value="55" hexvalue="37" since="5.1" />
 
 <function name="PerformAppServiceInteraction" functionID="PerformAppServiceInteractionID" messagetype="request">
 
@@ -986,13 +990,13 @@ The HMI will be responsible for the actual selection and activation of app servi
 
 ```xml
 <function name="GetAppServiceRecords" messagetype="request">
-  <param name="serviceTypes" type="Common.ServiceType" mandatory="false">
-    <description>If included, only service records of supplied type will be returned in response. If not included, all service records for all types will be returned.</description>
+  <param name="serviceType" type="String" mandatory="false">
+    <description>If included, only service records of supplied type will be returned in response. If not included, all service records for all types will be returned. See AppServiceType</description>
   </param>
 </function>
 
 <function name="GetAppServiceRecords" messagetype="response">
-  <param name="serviceRecords" type="Common.AppServiceRecord" array="true"mandatory="false">
+  <param name="serviceRecords" type="Common.AppServiceRecord" array="true" mandatory="false">
     <description>All app service records of requested type.</description>
   </param>
 </function>
@@ -1003,7 +1007,7 @@ The HMI will be responsible for the actual selection and activation of app servi
     <description>The ID of the service that should have an activation event take place on</description>
   </param>
   <param name="serviceType" type="String" mandatory="true">
-    <description>The service type the service should have the activation event occur on</description>
+    <description>The service type the service should have the activation event occur on. See AppServiceType</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
     <description>True if the service is to be activated. False if the app is to be deactivated</description>
@@ -1018,7 +1022,7 @@ The HMI will be responsible for the actual selection and activation of app servi
     <description>The ID of the service that was requested to have an activation event take place</description>
   </param>
   <param name="serviceType" type="String" mandatory="true">
-    <description>The service type the service that was requested to have an activation event take place</description>
+    <description>The service type the service that was requested to have an activation event take place. See AppServiceType</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
     <description>True if the service was activated. False if the app was deactivated or unable to be activated</description>

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -1022,7 +1022,7 @@ The HMI will be responsible for the actual selection and activation of app servi
     <description>The ID of the service that was requested to have an activation event take place</description>
   </param>
   <param name="serviceType" type="String" mandatory="true">
-    <description>The service type **of** the service that was requested to have an activation event take place. See AppServiceType</description>
+    <description>The service type of the service that was requested to have an activation event take place. See AppServiceType</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
     <description>True if the service was activated. False if the app was deactivated or unable to be activated</description>

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -471,7 +471,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 
 ```xml
 	<struct name="AppServiceManifest">
-		<description> This manifest contains all the information necessary for the service to be published, activated, and consumers able to interact with it</description>
+		<description>This manifest contains all the information necessary for the service to be published, activated, and allow consumers to interact with it</description>
 		
 		<param name="serviceName" type="String" mandatory="false">
 			<description> Unique name of this service</description>
@@ -1007,7 +1007,7 @@ The HMI will be responsible for the actual selection and activation of app servi
     <description>The ID of the service that should have an activation event take place on</description>
   </param>
   <param name="serviceType" type="String" mandatory="true">
-    <description>The service type the service should have the activation event occur on. See AppServiceType</description>
+    <description>The service type of the service should have the activation event occur on. See AppServiceType</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
     <description>True if the service is to be activated. False if the app is to be deactivated</description>
@@ -1022,7 +1022,7 @@ The HMI will be responsible for the actual selection and activation of app servi
     <description>The ID of the service that was requested to have an activation event take place</description>
   </param>
   <param name="serviceType" type="String" mandatory="true">
-    <description>The service type the service that was requested to have an activation event take place. See AppServiceType</description>
+    <description>The service type **of** the service that was requested to have an activation event take place. See AppServiceType</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
     <description>True if the service was activated. False if the app was deactivated or unable to be activated</description>
@@ -1086,7 +1086,7 @@ Proposed policy table structure:
             }
 ```
 
-In the policy table, the `app_policies` section will have a new `app_services` object parameter. Each object will have the service type as the object key. `service_names` will be an array of allowed app service nick names. `handled_rpcs` will be an array of objects to with the function_id of allowed handled rpcs. `handled_rpcs` as an array of objects instead of an array of integers will allow for future expansion of the `handled_rpcs` permission item.
+In the policy table, the `app_policies` section will have a new `app_services` object parameter. Each object will have the service type as the object key. `service_names` will be an array of allowed app service nick names. `handled_rpcs` will be an array of objects with the function_id of allowed handled rpcs. `handled_rpcs` will be an array of objects instead of an array of integers, this will allow for future expansion of the `handled_rpcs` permission item.
 
 If an app tries to publish an app service with information that does not match the policy table entry, the request will be disallowed.
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -482,7 +482,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 		</param>
 		
 		<param name="serviceIcon" type="Image" mandatory="false">
-			<description> The image object be associated with this service. Most likely the same as the appIcon.</description>
+			<description> The icon to be associated with this service. Most likely the same as the appIcon.</description>
 		</param>
 		
 		<param name="allowAppConsumers" type="Boolean" mandatory="false" defvalue="false">

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -41,7 +41,7 @@ Services will be defined to a few high level categories so that we can support t
 _Same for both MOBILE\_API and HMI\_API._
 
 ```xml
-<enum name="AppServiceType">
+<enum name="AppServiceType" platform="documentation">
 	 <element name = "MEDIA"/>
 	 <element name = "WEATHER"/>
 	 <element name = "NAVIGATION"/>
@@ -192,10 +192,10 @@ A weather service is defined as a service that can provide weather data.
         <description> This data is related to what a weather service would provide</description>
         <param name="location" type="LocationDetails" mandatory="true"/>
         <param name="currentForecast" type="WeatherData" mandatory="false"/>
-        <param name="minuteForecast" type="WeatherData" array="true" minSize="15" maxSize="60" mandatory="false" />
-        <param name="hourlyForecast" type="WeatherData" array="true" minsize="1" maxSize="96" mandatory="false" />
-        <param name="multidayForecast" type="WeatherData" array="true" minsize="1" maxSize="30" mandatory="false" />
-        <param name="alerts" type="WeatherAlert" array="true" minsize="1" maxSize="10" mandatory="false" />
+        <param name="minuteForecast" type="WeatherData" array="true" minsize="15" maxsize="60" mandatory="false" />
+        <param name="hourlyForecast" type="WeatherData" array="true" minsize="1" maxsize="96" mandatory="false" />
+        <param name="multidayForecast" type="WeatherData" array="true" minsize="1" maxsize="30" mandatory="false" />
+        <param name="alerts" type="WeatherAlert" array="true" minsize="1" maxsize="10" mandatory="false" >
             <description> This array should be ordered with the first object being the current day</description>
         </param>
     </struct>
@@ -259,7 +259,7 @@ A weather service is defined as a service that can provide weather data.
         <param name="title" type="String" mandatory="false" />
         <param name="summary" type="String" mandatory="false" />
         <param name="expires" type="DateTime" mandatory="false" />
-        <param name="regions" type="String" array="true" minSize="1" maxSize="99" mandatory="false" />
+        <param name="regions" type="String" array="true" minsize="1" maxsize="99" mandatory="false" />
         <param name="severity" type="String" mandatory="false" />
         <param name="timeIssued" type="DateTime" mandatory="false" />
     </struct>
@@ -471,21 +471,21 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 
 ```xml
 	<struct name="AppServiceManifest">
-		<description> This manfifest contains all the information necessary for the service to be published, activated, and consumers able to interact with it</description>
+		<description> This manifest contains all the information necessary for the service to be published, activated, and consumers able to interact with it</description>
 		
 		<param name="serviceName" type="String" mandatory="false">
 			<description> Unique name of this service</description>
 		</param>
 		
-		<param name="serviceType" type="AppServiceType" mandatory="true">
+		<param name="serviceType" type="String" mandatory="true">
 			<description>The type of service that is to be offered by this app</description>
 		</param>
 		
-		<param name="serviceIcon" type="String" mandatory="false">
+		<param name="serviceIcon" type="Image" mandatory="false">
 			<description> The file name of the icon to be associated with this service. Most likely the same as the appIcon.</description>
 		</param>
 		
-		<param name="allowAppConsumers" type="Boolean" mandatory="false" defValue="false">
+		<param name="allowAppConsumers" type="Boolean" mandatory="false" defvalue="false">
 			<description>If true, app service consumers beyond the IVI system will be able to access this service. If false, only the IVI system will be able consume the service. If not provided, it is assumed to be false. </description>
 		</param>
 
@@ -493,7 +493,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 		<param name="uriPrefix" type="String" mandatory="false">
 			<description> The URI prefix for this service. If provided, all PerformAppServiceInteraction requests must start with it.</description>
 		</param>
-		<param name="uriScheme" type="JSONObject" mandatory="false">
+		<param name="uriScheme" type="String" mandatory="false">
 			<description> This is a custom schema for this service. SDL will not do any verification on this param past that it has a correctly formated JSON Object as its base. The uriScheme should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. </description>
 		</param>
 		
@@ -501,7 +501,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 		<param name="rpcSpecVersion" type="SyncMsgVersion" mandatory="false">
 			<description> This is the max RPC Spec version the app service understands. This is important during the RPC passthrough functionality. If not included, it is assumed the max version of the module is acceptable. </description>
 		</param>
-		<param name="handledRPCs" type="FunctionID" array="true" mandatory="false">
+		<param name="handledRPCs" type="Integer" array="true" mandatory="false">
 			<description> This field contains the Function IDs for the RPCs that this service intends to handle correctly. This means the service will provide meaningful responses. </description>
 		</param>
 		
@@ -522,6 +522,8 @@ The next action the App Service has to take is publishing their service. This is
 
 
 ```xml
+<element name="PublishAppServiceID" value="52" hexvalue="34" since="5.1" />
+
 <function name="PublishAppService" functionID="PublishAppServiceID" messagetype="request">
 	<description>Registers a service offered by this app on the module</description>
 
@@ -571,27 +573,27 @@ _Same for both MOBILE\_API and HMI\_API._
 
 ```xml
 <enum name="ServiceUpdateReason">
-	 <element name = "PUBLISHED">
-	 	<description> The service has just been published with the module and once activated to the primary service of its type, it will be ready for possible consumption.</description>
+	 <element name="PUBLISHED">
+	 	<description>The service has just been published with the module and once activated to the primary service of its type, it will be ready for possible consumption.</description>
 	 </element>
-	 <element name = "REMOVED">
-	 	<description> The service has just been unpublished with the module and is no longer accessible</description>
+	 <element name="REMOVED">
+	 	<description>The service has just been unpublished with the module and is no longer accessible</description>
 	 </element>
-	 <element name = "ACTIVATED">
-	 	<description> The service is activated as the primary service of this type. All requests dealing with this service type will be handled by this service.</description>
+	 <element name="ACTIVATED">
+	 	<description>The service is activated as the primary service of this type. All requests dealing with this service type will be handled by this service.</description>
 	 </element>
-	 <element name = "DEACTIVATED">
-	 	<description> The service has been deactivated as the primary service of its type</description>
+	 <element name="DEACTIVATED">
+	 	<description>The service has been deactivated as the primary service of its type</description>
 	 </element>
-	 <element name = "MANIFEST_UPDATE">
-	 	<description> The service has updated its manifest. This could imply updated capabilities</description>
+	 <element name="MANIFEST_UPDATE">
+	 	<description>The service has updated its manifest. This could imply updated capabilities</description>
 	 </element>
 </enum>
 
 <struct name="AppServiceRecord">
 	<description> This is the record of an app service publisher that the module has. It should contain the most up to date information including the service's active state</description>
 	
-	<param name="serviceId" type="String" mandatory="true">
+	<param name="serviceID" type="String" mandatory="true">
 		<description> A unique ID tied to this specific service record. The ID is supplied by the module that services publish themselves. </description>
 	</param>
 	
@@ -609,6 +611,7 @@ _Same for both MOBILE\_API and HMI\_API._
 </struct>
 
 ```
+Note: A published app services can change the capabilities of other systemCapabilityType(s) and trigger a corresponding onSystemCapabilityUpdated for that type. For example, an app that publishes a navigation service on a head unit that does not support navigation will send onSystemCapabilityUpdated notifications to apps that are subscribed to systemCapabilityTypes NAVIGATION and/or APP_SERVICES.
 
 ##### Notifying provider of removal
 
@@ -636,7 +639,9 @@ When a service sends a `PublishAppService` request it will automatically be subs
 
 _Note: There should be a separate proposal to update the existing `SystemCapability` structs._ 
 
-```
+```xml
+<element name="OnSystemCapabilityUpdatedID" value="32787" hexvalue="8013" since="5.1" />
+
 <function name="GetSystemCapability" functionID="GetSystemCapabilityID" messagetype="request">
     <description>Request for expanded information about a supported system/HMI capability</description>
     
@@ -672,16 +677,11 @@ _Note: There should be a separate proposal to update the existing `SystemCapabil
 ```xml
 <struct name="SystemCapability">
 	...
-	<param name="appServicesCapabilities" type="AppServicesCapabilities" mandatory="false"/>
+	<param name="appServiceCapability" type="AppServicesCapabilities" mandatory="false"/>
 </struct>
     
 <struct name="AppServicesCapabilities">
 	<description> Capabilities of app services including what service types are supported and the current state of services. </description>
-	
-	<param name="servicesSupported" type="AppServiceType" array="true" mandatory="true">
-	    <description> An array of supported app service types</description>
-	</param>	
-   
    	<param name="appServices" type="AppServiceCapability" array="true" mandatory="false">
    	    <description> An array of currently available services. If this is an update to the capability the affected services will include an update reason in that item</description>
    	</param>
@@ -700,6 +700,10 @@ _Note: There should be a separate proposal to update the existing `SystemCapabil
 
 
 ```
+
+Note: `onSystemCapabilityUpdated` notification for type `APP_SERVICES` contains all known active service records, even if only one app service is updated. The service(s) that was updated will contain the `updateReason` parameter.
+
+
 ##### Get service data
 
 The app service consumer can then decide which services it wants to get more info from and even subscribe to for future updates from the service.
@@ -711,8 +715,8 @@ When requesting the data from the app service the developer can expect the data 
 <struct name="AppServiceData">
 	<description> Contains all the current data of the app service. The serviceType will link to which of the service data objects are included in this object. (eg if service type equals MEDIA, the mediaServiceData param should be included.</description>
 	
-	<param name="serviceType" type="AppServiceType" mandatory="true"/>
-	<param name="serviceId" type="String" mandatory="true"/>
+	<param name="serviceType" type="String" mandatory="true"/>
+	<param name="serviceID" type="String" mandatory="true"/>
 		
 	<param name="mediaServiceData" type="MediaServiceData" mandatory="false"/>
 	<param name="weatherServiceData" type="WeatherServiceData" mandatory="false"/>
@@ -732,10 +736,12 @@ Now that we know what to expect in terms of the actual data, the next piece will
 The response from a `GetAppServiceData`  should include all service data that is currently available. This is different from the `OnAppServiceData` that will be discussed below. 
 
 ```xml
+<element name="GetAppServiceDataID" value="53" hexvalue="35" since="5.1" />
+
 <function name="GetAppServiceData" functionID="GetAppServiceDataID" messagetype="request">
 	<description> This request asks the module for current data related to the specific service. It also includes an option to subscribe to that service for future updates</description>
 	
-	<param name="serviceType" type="AppServiceType" mandatory="true"/>
+	<param name="serviceType" type="String" mandatory="true"/>
 	
 	<param name="subscribe" type="Boolean" mandatory="false">
 		<description> If true, the consumer is requesting to subscribe to all future updates from the service publisher. If false, the consumer doesn't wish to subscribe and should be unsubscribed if it was previously subscribed.</description>
@@ -782,6 +788,8 @@ If the app service consumer subscribed to updates from the app service provider 
 Notifications will come through as data changes. Only the data that changed should be expected to be included. This prevents the provider and subscriber traffic from becoming too large. However, it is recommended that these be batched together when possible to avoid constant traffic.
 
 ```xml
+<element name="OnAppServiceDataID" value="32786" hexvalue="8012" since="5.1" />
+
 <function name="OnAppServiceData" functionID="OnAppServiceDataID" messagetype="notification">
 	<description> This notification includes the data that is updated from the specific service</description>
 	
@@ -800,6 +808,8 @@ One of the aspects to publishing services will be to include data beyond simple 
 When an app service consumer receives an `AppServiceData` object that contains file names of the media that the app service provider intends to share they will need to send a `GetFile` request. The structure of the `GetFile` request/response pair is very similar to that of the `PutFile` pair.
 
 ```xml
+<element name="GetFileID" value="54" hexvalue="36" since="5.1" />
+
 <function name="GetFile" functionID="GetFileID" messagetype="request">
 	<description> This request is sent to the module to retrieve a file</description>
 
@@ -888,13 +898,15 @@ SDL should make no guarantees that:
 
 
 ```xml
+<element name="PerformAppServiceInteractiontFileID" value="55" hexvalue="37" since="5.1" />
+
 <function name="PerformAppServiceInteraction" functionID="PerformAppServiceInteractionID" messagetype="request">
 
 	<param name="serviceUri" type="String"  mandatory="true">
 		<description>Fully qualified URI based on the URI prefix and URI scheme the app service provided. SDL makes no gurantee that this URI is correct.</description>
 	</param>
 	
-	<param name="appServiceId" type="String" mandatory="true">
+	<param name="serviceID" type="String" mandatory="true">
 		<description> The service ID that the app consumer wishes to send this URI.</description>
 	</param>
 	
@@ -946,10 +958,6 @@ CoresOriginId = "sdl_core"
 
 ; Services that exist on the module. Values are of AppServiceType in RPC Spec. These services will be used as default and app services will only become primary service publisher with direct user interaction. These services will also be a fallback if no app service publisher is registered with the system of that type.
 EmbeddedServices = MEDIA, WEATHER, NAVIGATION, VOICE_ASSISTANT, COMMUNICATION_VOIP, MESSAGING, TTS
-
-; App services that are supported by the module. Values are of AppServiceType in RPC Spec. If an app attempts to publish a service of a type that is not listed here it will be rejected.
-SupportedAppServices = MEDIA, WEATHER, NAVIGATION, VOICE_ASSISTANT, COMMUNICATION_VOIP, MESSAGING, TTS
-
  
 ; Additional time added to RPC timeout when passing through to App service
 RpcPassThroughTimeout = 10000
@@ -991,10 +999,10 @@ The HMI will be responsible for the actual selection and activation of app servi
 
 
 <function name="AppServiceActivation" messagetype="request">
-  <param name="serviceId" type="String" mandatory="true" >
+  <param name="serviceID" type="String" mandatory="true" >
     <description>The ID of the service that should have an activation event take place on</description>
   </param>
-  <param name="serviceType" type="Common.ServiceType" mandatory="true">
+  <param name="serviceType" type="String" mandatory="true">
     <description>The service type the service should have the activation event occur on</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
@@ -1006,10 +1014,10 @@ The HMI will be responsible for the actual selection and activation of app servi
 </function>
 
 <function name="AppServiceActivation" messagetype="response">
-  <param name="serviceId" type="String" mandatory="true" >
+  <param name="serviceID" type="String" mandatory="true" >
     <description>The ID of the service that was requested to have an activation event take place</description>
   </param>
-  <param name="serviceType" type="Common.ServiceType" mandatory="true">
+  <param name="serviceType" type="String" mandatory="true">
     <description>The service type the service that was requested to have an activation event take place</description>
   </param>
   <param name="activate" type="Boolean" mandatory="true">
@@ -1049,6 +1057,34 @@ Core will need to parse and store received params even if they are not listed in
 ##### Policy Table
 
 The IVI system can enable/disable app service providers from offering their services and consumers from using them through additions to the policy table. New functional groups will be introduced for `AppServiceProvider` and `AppServiceConsumer`. Furthermore, the functional groups can become more granular to provide access to publishing/consuming of specific app service types.
+
+Proposed policy table structure:
+```
+        "app_policies": {
+            "SDLSuperApp12345": {
+                "keep_context": false,
+                "steal_focus": false,
+                "priority": "NONE",
+                "default_hmi": "NONE",
+                "groups": ["Base-4"],
+                "RequestType": [],
+                "RequestSubType": [],
+                "app_services": {
+                    "MEDIA": {
+                        "service_names": ["SDL Music", "App Music"],
+                        "handled_rpcs": [{"function_id": 41}]
+                        },
+                    "NAVIGATION": {
+                        "service_names": ["SDL Navigation", "App Navigation"],
+                        "handled_rpcs": [{"function_id": 39}]                    
+                    }
+                }
+            }
+```
+
+In the policy table, the `app_policies` section will have a new `app_services` object parameter. Each object will have the service type as the object key. `service_names` will be an array of allowed app service nick names. `handled_rpcs` will be an array of objects to with the function_id of allowed handled rpcs. `handled_rpcs` as an array of objects instead of an array of integers will allow for future expansion of the `handled_rpcs` permission item.
+
+If an app tries to publish an app service with information that does not match the policy table entry, the request will be disallowed.
 
 
 ## Potential downsides


### PR DESCRIPTION
Fix various typos and unify naming conventions.

Make AppServiceType a documentation item and change all uses of the AppServiceType to String. This will allow for support of future app services that core does not recognize.

Add notes regarding system capability updates.

Change serviceIcon type to Image.

Change uriScheme to type String.

Change handledRPCs type to Integer. Change is for similar reasons that appServiceType should be sent as a String. Also handledRPCs as an integer will allow for better integration with policies.

Defined functionIDs for new RPCs.

Remove servicesSupported from AppServicesCapabilities. The available serviceTypes can be found in the appServices parameter. appServices -> updatedAppServiceRecord -> serviceManifest -> serviceType.

Remove configuration for supportedAppServices in the ini file. Proposal states that core should be able to handle future unknown service types with conflicts with defining service types in core’s static ini file.

Define policy table structure.