### PR TITLE
App Services - Structure PerformAppServiceInteraction URIs

### DIFF
--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -416,7 +416,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 		</param>
 
 		<param name="uriActionSheet" type="ServiceAction" array="true" mandatory="false">
-			<description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose Quick Action actions, the list should be ordered with the most important at index 0. </description>
+			<description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose `Quick Action `actions, the list should be ordered with the most important at index 0. </description>
 		</param>
 		
 	
@@ -449,11 +449,11 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 	    </param>
 	    
 	    <param name="isQuickAction" type="Boolean" mandatory="false">
-	        <description>If set to true, this implies this action can be acted upon without an additional parameters or actions. Most common use case would be a consumer displaying a soft button to represent this action</description>
+	        <description>If set to true, this implies this action can be acted upon without any additional parameters or actions. The most common use case would be a consumer displaying a soft button to represent this action</description>
 	    </param>
 	    
 	    <param name="icon" type="Image" mandatory="false">
-	        <description>The file name of an image that can be used in association with this action. Most common use case is this used when the action</description>
+	        <description>The file name of an image that can be used in association with this action. A use case for this image would be to display the action as a button on a widget.</description>
 	    </param>
 	
 	</struct>

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -412,10 +412,11 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 
 				
 		<param name="uriPrefix" type="String" mandatory="false">
-			<description> The URI prefix for this service. If provided, all PerformAppServiceInteraction requests must start with it. This can also be referred to as the scheme of the URI.</description>
+			<description> The URI prefix for this service. If provided, all PerformAppServiceInteraction requests must start with it. This can also be referred to as the scheme of the URI. This scheme, if included, will be followed by a colon (:) as well as two slashes (//) if the service action includes a baseUri. If this is not included the uri shall start with a single slash (/). For example, uriPrefix://baseUri?parameters or uriPrefix:paramters or /baseUri?parameters </description>
 		</param>
+
 		<param name="uriActionSheet" type="ServiceAction" array="true" mandatory="false">
-			<description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose Quick Action actions, the list should be ordered with the most important at index 0.  </description>
+			<description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose Quick Action actions, the list should be ordered with the most important at index 0. </description>
 		</param>
 		
 	
@@ -436,15 +437,22 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 	
 	<struct name="ServiceAction">
 	    <param name="baseUri" type="String" mandatory="true">
-	        <description> Also referred to as the authority and path of the URI. The base URI of this action. If no params are required, this plus the URI prefix can be used as the entire URI. If this param is left as an empty set, params will be assumed to be part of the path of the URI and the fully qualified URI will be constructed accordingly.</description>
+	        <description> Also referred to as the authority and path of the URI. The base URI of this action. If no params are required, this plus the URI prefix can be used as the entire URI (uriPrefix://baseUri?paramKey=paramValue&paramKey=paramValue#paramKey=paramValue). If this param is left as an empty set, params will be assumed to be part of the path of the URI with no keys and the fully qualified URI will be constructed accordingly (uriPrefix:param:param:param).</description>
 	    </param>
-	    <param name="actionParameters" type="Parameter" array="true" mandatory="false">
-	        <description>An array of parameters for this action. When sent as a fully qualified URI these parameters will be attached in accordance to RFC3986 https://tools.ietf.org/html/rfc3986</description>
+	    
+	    <param name="queryParameters" type="Parameter" array="true" mandatory="false">
+	        <description>An array of parameters for this action that should be included as part of the query string of the URI. When sent as a fully qualified URI these parameters will be attached in accordance to RFC3986 https://tools.ietf.org/html/rfc3986</description>
 	    </param>
+	    
+	    <param name="fragmentParameters" type="Parameter" array="true" mandatory="false">
+	        <description>An array of parameters for this action that should be included in the fragment section of the URI. When sent as a fully qualified URI these parameters will be attached in accordance to RFC3986 https://tools.ietf.org/html/rfc3986</description>
+	    </param>
+	    
 	    <param name="isQuickAction" type="Boolean" mandatory="false">
 	        <description>If set to true, this implies this action can be acted upon without an additional parameters or actions. Most common use case would be a consumer displaying a soft button to represent this action</description>
 	    </param>
-	    <param name="iconFileName" type="String" mandatory="false">
+	    
+	    <param name="icon" type="Image" mandatory="false">
 	        <description>The file name of an image that can be used in association with this action. Most common use case is this used when the action</description>
 	    </param>
 	
@@ -457,15 +465,15 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 	    </param>
 	    
 	    <param name="type" type="String" mandatory="true">
-	        <description></description>
+	        <description>The provided type of this object. For example String, boolean, etc. However, when put into the action URI they will all be converted to string representations.</description>
 	    </param>
 	    
 	    <param name="isArray" type="boolean" mandatory="false">
-	        <description></description>
+	        <description>True if this parameter is intended to be an array of the included type, false if it is not an array.</description>
 	    </param>
 	    
 	    <param name="isMandatory" type="boolean" mandatory="false">
-	        <description></description>
+	        <description>True if the parameter is required, false if it is optional.</description>
 	    </param>
 	</struct>
 	

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -416,7 +416,7 @@ The `AppServiceManifest` is essentially detailing everything about a particular 
 		</param>
 
 		<param name="uriActionSheet" type="ServiceAction" array="true" mandatory="false">
-			<description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose `Quick Action `actions, the list should be ordered with the most important at index 0. </description>
+			<description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose `Quick Action` actions, the list should be ordered with the most important at index 0. </description>
 		</param>
 		
 	


### PR DESCRIPTION
# App Services - Structure PerformAppServiceInteraction URIs

* Proposal: [SDL-0167](0167-app-services.md)
* Author: [Joey Grover](https://github.com/joeygrover)
* Status: **Awaiting review**
* Impacted Platforms: [Core / iOS / Android / Web / RPC ]

## Introduction

This PR/proposal is to add structure to the action sheet and URIs that are used in the `PerformAppServiceInteraction` RPC. It has come to our attention that structuring the data will help the app services feature be a more complete solution and introduce new use cases (widgets, app cards, etc). The structure is based on the [RFC 3986](https://tools.ietf.org/html/rfc3986) definition of URIs and new RPC messages/structs, which was created to better fit within the SDL Protocol.

## Motivation

The first iteration of the App Services features included a way for app service consumers to perform actions on the app service publisher. This was performed through a three step process.

1. When the App Service Publisher first published their service, they included both a `uriPrefix` and `uriActionSheet` in their `AppServiceManifest`. This parameter's structure was completely left up to the app service publisher. 
2. An app service consumer would retrieve the app service manifest  for a specific app service. It would then have to know how to parse the supplied `uriActionSheet` if it wished to perform a specific action.
3. The app service consumer would then fill out a URI based on the supplied information in the app service publisher's manifest and use a `PerformAppServiceInteraction` with the supplied URI to perform the action.

This change request relates to the first two steps. While it introduces the ability for app service publishers to publish any type of API they want through this mechanism, it becomes nearly impossible for an app service consumer to be compatible with all of them. By providing a structure to the action sheet, app service consumers can dynamically use a lot of the apps features without needing custom parsers.

Because structure is being added to the API, a few extra parameters will be added so that the integration steps are more feature rich. This includes the ability to add an image to an action. Also, adding a flag that lets the app service consumer know that the specific URI provided doesn't need any parameters attached and the URI can be sent to perform an action.

## Proposed solution

The proposed solution is to structure the `uriActionSheet ` and give them clearer definitions. The new structure will use the spec provided in [RFC 3986](https://tools.ietf.org/html/rfc3986) and build RPC structures around it.

Services expose their API using the `uriActionSheet` param. When defining the specific actions and URI, developers should look to the URI standard in RFC3986 and more specifically section [3. Syntax Components](https://tools.ietf.org/html/rfc3986#section-3)

`uriPrefix` + (`action.baseUri` + `action.parameters[]`) = Fully Qualified URI

#### AppServiceManifest

First thing that needs updating is the `AppServiceManifest`, for brevity it will only include the parameters that are being changed:


```xml

    <struct name="AppServiceManifest">
        <description> This manfifest contains all the information necessary for the service to be published, activated, and consumers able to interact with it</description>
        
        <param name="uriPrefix" type="String" mandatory="false">
            <description> The URI prefix for this service. If provided, all PerformAppServiceInteraction requests must start with it. This can also be referred to as the scheme of the URI. This scheme, if included, will be followed by a colon (:) as well as two slashes (//) if the service action includes a baseUri. If this is not included the uri shall start with a single slash (/). For example, uriPrefix://baseUri?parameters or uriPrefix:paramters or /baseUri?parameters </description>
        </param>
        
        <param name="uriActionSheet" type="ServiceAction" array="true" mandatory="false">
            <description> This is a custom schema for this service. Each of the actions should be formatted into a ServiceAction object that contains basic information to ensure consumers can read the data. The uriActionSheet should contain all available actions to be taken through a PerformAppServiceInteraction request from an app service consumer. If the app intends to expose Quick Action actions, the list should be ordered with the most important at index 0. </description>
        </param>
    </struct>
```
#### ServiceAction

This is the bases of the new structure. This struct was based on the RFC 3986 as close as possible while adapting it to the SDL RPC protocol. Each parameter has an accurate description of what they are and can be cross referenced with the RFC spec. 

```xml
	
	<struct name="ServiceAction">
	    <param name="baseUri" type="String" mandatory="true">
	        <description> Also referred to as the authority and path of the URI. The base URI of this action. If no params are required, this plus the URI prefix can be used as the entire URI (uriPrefix://baseUri?paramKey=paramValue&paramKey=paramValue#paramKey=paramValue). If this param is left as an empty set, it will be assumed that the params will be part of the path of the URI with no keys and the fully qualified URI will be constructed accordingly (uriPrefix:param:param:param).</description>
	    </param>
	    
	    <param name="queryParameters" type="Parameter" array="true" mandatory="false">
	        <description>An array of parameters for this action that should be included as part of the query string of the URI. When sent as a fully qualified URI these parameters will be attached in accordance to RFC3986 https://tools.ietf.org/html/rfc3986</description>
	    </param>
	    
	    <param name="fragmentParameters" type="Parameter" array="true" mandatory="false">
	        <description>An array of parameters for this action that should be included in the fragment section of the URI. When sent as a fully qualified URI these parameters will be attached in accordance to RFC3986 https://tools.ietf.org/html/rfc3986</description>
	    </param>
	    
	    <param name="isQuickAction" type="Boolean" mandatory="false">
	        <description>If set to true, this implies this action can be acted upon without an additional parameters or actions. Most common use case would be a consumer displaying a soft button to represent this action</description>
	    </param>
	    
	    <param name="icon" type="Image" mandatory="false">
	        <description>The file name of an image that can be used in association with this action. A use case for this image would be to display the action as a button on a widget. </description>
	    </param>
	
	</struct>
	
```


#### Parameter

This is an ease of use struct that will help app service consumers understand an app service publishers API in terms of what it expects. The parameters in this struct mimic the same keywords that exist in SDL's RPC spec.

```xml
<struct name="Parameter">
	    <description>Describes a parameter's attributes</description>
	    <param name="key" type="String" mandatory="false">
	        <description>The key or name to identify this parameter. If not provided it will be assumed that this parameter should be used as part of the path and a ":" delimiter should be attached before the value.</description>
	    </param>
	    
	    <param name="type" type="String" mandatory="true">
	        <description>The provided type of this object. For example String, boolean, etc. However, when put into the action URI they will all be converted to string representations.</description>
	    </param>
	    
	    <param name="isArray" type="boolean" mandatory="false">
	        <description>True if this parameter is intended to be an array of the included types, false if it is not an array.</description>
	    </param>
	    
	    <param name="isMandatory" type="boolean" mandatory="false">
	        <description>True if the parameter is required, false if it is optional.</description>
	    </param>
	</struct>
	
```


## Potential downsides

The biggest issue going from unstructured to structured is that app service publishers will be required to translate their api into the supplied structs. It is believed that the SDLC could create helpful tools for them that could take a sample URI and build the necessary structs around it. 


## Impact on existing code

Since this proposal has not yet been implemented, there is no impact on the existing code.

## Alternatives considered

- Only alternative considered is keeping the parameter unstructured. 