### PR TITLE
Explicit returned type from NSDictionary(Store) category

### DIFF
--- a/proposals/NNNN-ios-check-type.md
+++ b/proposals/NNNN-ios-check-type.md
@@ -7,13 +7,13 @@
 
 ## Introduction
 
-**This proposal is to** specify returned types from NSDictionary (Store).
+This proposal is to specify returned types from NSDictionary (Store).
 This ensures that the return value is assigned to a variable of the correct type. 
 
 ## Motivation
 
-Method (`-(nullable id)sdl_objectForName:(SDLName)name`) in NSDictionary (Store) returns `id` in the future it can be casted to **any** type.
-As result **wrong casting** leads to **a crash in runtime**.
+Method (`-(nullable id)sdl_objectForName:(SDLName)name`) in NSDictionary (Store) returns `id` in the future it can be casted to any type.
+As result wrong casting leads to a crash in runtime.
 For example:
 ````
 - (SDLLanguage)languageDesired {
@@ -30,13 +30,13 @@ For example:
 
 ## Proposed solution
 
-**Remove method** :
+Remove method :
 `-(nullable id)sdl_objectForName:(SDLName)name;`. 
 
-**Instead of** removed method use **existing method**:
+Instead of removed method use existing method:
 `- (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;`.
 
-**For suitable** working with **SDLEnums** create methods:
+For suitable working with SDLEnums create methods:
 `- (nullable SDLEnum)sdl_enumForName:(SDLName)name`
 `- (nullable NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;`
 
@@ -60,7 +60,7 @@ Proposal implemented in https://github.com/smartdevicelink/sdl_ios/pull/1158
 
 ## Potential downsides
 
-Store returns **nil** by getting with the **wrong key** or **incorrect type** without **highlighting **the** on compile time**.
+Store returns `nil` by getting with the wrong key or incorrect type without highlighting the on compile time.
 For example: 
 ````
 NSNumber *number = @2;
@@ -72,7 +72,7 @@ NSString *string = [self.store sdl_objectForName:SDLSomeValue ofClass:NSString.c
 
 ## Impact on existing code
 
-Possible nullability issues when classes expect **nonnull** value can be returned **nil**.
+Possible nullability issues when classes expect nonnull value can be returned nil.
 
 For example:
 ```
@@ -108,7 +108,7 @@ NS_ASSUME_NONNULL_END
     }
 }
 ```
-Now, someProperty **isn't** nil, after **applying** changes someProperty would be **nil**.
+Now, someProperty isn't nil, after applying changes someProperty would be nil.
 
 ## Alternatives considered
 

--- a/proposals/NNNN-ios-check-type.md
+++ b/proposals/NNNN-ios-check-type.md
@@ -33,7 +33,7 @@ For example:
 Remove method :
 `-(nullable id)sdl_objectForName:(SDLName)name;`. 
 
-Instead of removed method use existing method:
+Instead of the removed method, use this existing method:
 `- (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;`.
 
 For suitable working with SDLEnums create the following methods:

--- a/proposals/NNNN-ios-check-type.md
+++ b/proposals/NNNN-ios-check-type.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-Specify returned types from NSDictionary (Store). 
+**This proposal is to** specify returned types from NSDictionary (Store).
 This ensures that the return value is assigned to a variable of the correct type. 
 
 ## Motivation
@@ -60,7 +60,7 @@ Proposal implemented in https://github.com/smartdevicelink/sdl_ios/pull/1158
 
 ## Potential downsides
 
-Store returns **nil** by getting with **wrong key** or **incorect type** without **highlighting on compile time**. 
+Store returns **nil** by getting with the **wrong key** or **incorrect type** without **highlighting **the** on compile time**.
 For example: 
 ````
 NSNumber *number = @2;

--- a/proposals/NNNN-ios-check-type.md
+++ b/proposals/NNNN-ios-check-type.md
@@ -1,0 +1,82 @@
+```
+# Feature name
+
+* Proposal: [SDL-NNNN](NNNN-ios-check-type.md)
+* Author: [Misha Vyrko](https://github.com/mvyrko)
+* Status: **Awaiting review**
+* Impacted Platforms: [iOS]
+
+## Introduction
+
+Method (`-(nullable id)sdl_objectForName:(SDLName)name`) in NSDictionary (Store) returns objects as NSObject. 
+
+Clients(`SDLRegisterAppInterface`, `SDLChangeRegistration` and etc) force cast(without checking) the value(NSObject) from the method to type that they want to have NSNumber, NSString, SDLLanguage and etc.
+I suggest to require to specify the type explicitly.
+Remove method: `- (nullable id)sdl_objectForName:(SDLName)name;`
+Use existing method: `- (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;` 
+
+
+## Motivation
+
+Returned value type isn't checked at compile time as result we have a lot of crashes in app where one type replaced by another.
+`-[NSNull count]: unrecognized selector sent to instance 0x1e99699d0`
+`-[__NSDictionaryI firstObject]: unrecognized selector sent to instance 0x282447e80`
+`-[__NSCFNumber isEqualToEnum:]: unrecognized selector sent to instance 0xecbbf7f37a5c3eb2`
+
+Checking type at compile time increase stability and resolve problems with unrecognized selector sent to instance.
+
+
+## Proposed solution
+
+Remove method `-(nullable id)sdl_objectForName:(SDLName)name;`. 
+In every classes replace method `-(nullable id)sdl_objectForName:(SDLName)name;`
+with `- (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType`.
+
+For suitable working with SDLEnums create methods:
+`- (nullable SDLEnum)sdl_enumForName:(SDLName)name`
+`- (nullable NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;`
+
+
+Examples:
+~~~~
+- (nullable NSString *)fullAppID {
+    return [parameters sdl_objectForName:SDLNameFullAppID ofClass:NSString.class];
+}
+- (nullable NSArray<NSString *> *)vrSynonyms {
+    return [parameters sdl_objectsForName:SDLNameVRSynonyms ofClass:NSString.class];
+}
+- (SDLLanguage)languageDesired {
+    return [parameters sdl_enumForName:SDLNameLanguageDesired];
+}
+- (nullable NSArray<SDLVentilationMode> *)ventilationMode {
+    return [store sdl_enumsForName:SDLNameVentilationMode];
+}
+~~~~
+
+Possible solution https://github.com/smartdevicelink/sdl_ios/pull/1158
+
+## Potential downsides
+
+Possible nullability issues when clients expect nonnull value can be returned nil.
+
+## Impact on existing code
+
+Need to specify expected type.
+
+## Alternatives considered
+
+In every method check type like:
+~~~~
+- (nullable NSArray<NSString *> *)vrSynonyms {
+    id vrSynonyms = [parameters sdl_objectsForName:SDLNameVRSynonyms];
+    if ([vrSynonyms isKindOfClass:NSArray.class]) {
+        id firstSynonym = vrSynonyms.first;
+        if ([firstSynonym isKindOfClass:NSString.class]) {
+            return vrSynonyms;
+        }
+    }
+    return nil;
+}
+~~~~
+
+```

--- a/proposals/NNNN-ios-check-type.md
+++ b/proposals/NNNN-ios-check-type.md
@@ -1,4 +1,4 @@
-# Explicit returned type from NSDictrionary(Store) category
+# Explicit returned type from NSDictionary(Store) category
 
 * Proposal: [SDL-NNNN](NNNN-ios-check-type.md)
 * Author: [Misha Vyrko](https://github.com/mvyrko)

--- a/proposals/NNNN-ios-check-type.md
+++ b/proposals/NNNN-ios-check-type.md
@@ -36,7 +36,7 @@ Remove method :
 Instead of removed method use existing method:
 `- (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;`.
 
-For suitable working with SDLEnums create methods:
+For suitable working with SDLEnums create the following methods:
 `- (nullable SDLEnum)sdl_enumForName:(SDLName)name`
 `- (nullable NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;`
 


### PR DESCRIPTION
# Explicit returned type from NSDictionary(Store) category

* Proposal: [SDL-NNNN](NNNN-ios-check-type.md)
* Author: [Misha Vyrko](https://github.com/mvyrko)
* Status: **Awaiting review**
* Impacted Platforms: [iOS]

## Introduction

This proposal is to specify returned types from NSDictionary (Store).
This ensures that the return value is assigned to a variable of the correct type. 

## Motivation

Method (`-(nullable id)sdl_objectForName:(SDLName)name`) in NSDictionary (Store) returns `id` in the future it can be casted to any type.
As result wrong casting leads to a crash in runtime.
For example:
````
- (SDLLanguage)languageDesired {
    id object = [parameters sdl_objectForName:SDLNameLanguageDesired];
    return (SDLLanguage)object;
} 

- (void)someFunction:(SDLLanguage)language {
    if ([self.languageDesired isEqualToEnum:language]) { // `-[__NSCFNumber isEqualToEnum:]: unrecognized selector sent to instance`
        
    }
}
````

## Proposed solution

Remove method :
`-(nullable id)sdl_objectForName:(SDLName)name;`. 

Instead of the removed method, use this existing method:
`- (nullable id)sdl_objectForName:(SDLName)name ofClass:(Class)classType;`.

For suitable working with SDLEnums create the following methods:
`- (nullable SDLEnum)sdl_enumForName:(SDLName)name`
`- (nullable NSArray<SDLEnum> *)sdl_enumsForName:(SDLName)name;`

Examples:
~~~~
- (nullable NSString *)fullAppID {
    return [parameters sdl_objectForName:SDLNameFullAppID ofClass:NSString.class];
}
- (nullable NSArray<NSString *> *)vrSynonyms {
    return [parameters sdl_objectsForName:SDLNameVRSynonyms ofClass:NSString.class];
}
- (SDLLanguage)languageDesired {
    return [parameters sdl_enumForName:SDLNameLanguageDesired];
}
- (nullable NSArray<SDLVentilationMode> *)ventilationMode {
    return [store sdl_enumsForName:SDLNameVentilationMode];
}
~~~~

Proposal implemented in https://github.com/smartdevicelink/sdl_ios/pull/1158

## Potential downsides

Store returns `nil` by getting with the wrong key or incorrect type without highlighting the on compile time.
For example: 
````
NSNumber *number = @2;
self.store = @{SDLSomeValue : number};

NSString *string = [self.store sdl_objectForName:SDLSomeValue ofClass:NSString.class]; 
//string is always nil
````

## Impact on existing code

Possible nullability issues when classes expect nonnull value can be returned nil.

For example:
```
// In .h file
NS_ASSUME_NONNULL_BEGIN

@interface SDLSomeClass: NSObject

@property (nonatomic, strong) SDLSomeEnum someProperty;

- (instanceType)init {
    self = [super init];
    if(self) {
        NSNumber *number = @2;
        self.store = @{SDLSomeValue : number};
    }
    return self;
    }

@end

NS_ASSUME_NONNULL_END

// In .m file

- (SDLSomeEnum)someProperty {
    return [self.store sdl_objectForName:SDLSomeValue];
}

- (void)exampleFunction:(SDLSomeClass *)someClass {
    if(someClass.someProperty != nil) {
        // to do something
    }
}
```
Now, someProperty isn't nil, after applying changes someProperty would be nil.

## Alternatives considered

In every method add checking of type like:
~~~~
- (nullable NSArray<NSString *> *)vrSynonyms {
    id vrSynonyms = [parameters sdl_objectsForName:SDLNameVRSynonyms];
    if ([vrSynonyms isKindOfClass:NSArray.class]) {
        id firstSynonym = vrSynonyms.first;
        if ([firstSynonym isKindOfClass:NSString.class]) {
            return vrSynonyms;
        }
    }
    return nil;
}
~~~~