### PR TITLE
Revise SDL-0189 to remove UI/TTS OnResetTimeout and remove range for requested

### DIFF
--- a/proposals/0189-Restructuring-OnResetTimeout.md
+++ b/proposals/0189-Restructuring-OnResetTimeout.md
@@ -104,7 +104,8 @@ _OnResetTimeout_ function definition would be as follows for the _BasicCommunica
 	</param>
 </function>
 ```
-Since HMI API does not support(as i have been told) _deprecated_, we are going to remove the older implementation.
+
+Since HMI API does not support deprecated, it is going to be removed from the older implementations.
 
 **Note**: HMI Integration Guidelines will need to be updated to call out that currently there is no version negotiation between HMI and Core, so older HMI implementations will not work with this new version of Core as UI/TTS _OnResetTimeout_ will be removed.
 

--- a/proposals/0189-Restructuring-OnResetTimeout.md
+++ b/proposals/0189-Restructuring-OnResetTimeout.md
@@ -47,7 +47,7 @@ _OnResetTimeout_ function definition would be as follows for the _BasicCommunica
     <description>
 		HMI must send this notification to SDL for method instance for which timeout needs to be reset
     </description>	
-    <param name="requestID" type="Integer" minvalue="0" maxvalue="65535" mandatory="true">	
+    <param name="requestID" type="Integer" mandatory="true">	
 		<description>
 			Id between HMI and SDL which SDL used to send the request for method in question, for which timeout needs to be reset.
 		</description>
@@ -68,17 +68,15 @@ _OnResetTimeout_ function definition would be as follows for the _BasicCommunica
 
 **Note**: Though type needs to be Long for _resetPeriod_, I have kept it as Integer to maintain consistency in API as no other param uses Long irrespective of _maxvalue_
 
-**Note**: HMI Integration Guidelines will need to be updated to reflect that currently there is no version negotiation between HMI and Core, so older HMI implementations will not work with this new version of Core.
-
 * SDL can uniquely identify the request instance for which OnResetTimeout is being requested by HMI by using the ID between SDL<->HMI (_requestID_) and _methodName_
     * SDL uses unique ID across interfaces and apps, so we do not need appID to uniquely identify the function instance	
 * HMI would be responsible to fine tune the wait time per method call as needed. It is up to HMI to control number of reset timeouts and duration of each reset timeout for endless or finite method timeout.
 * This _OnResetTimeout_ function can be used across all the interfaces and for all the request functions.
 
-### UI: _OnResetTimeout would be deprecated:_
+### UI: _OnResetTimeout would be removed:_
 
 ```
-<function name="OnResetTimeout" messagetype="notification" deprecated="true" since="X.Y">
+<function name="OnResetTimeout" messagetype="notification">
 	<description>
 		HMI must provide SDL with notifications specific to the current Turn-By-Turn client status on the module
 	</description>
@@ -91,10 +89,10 @@ _OnResetTimeout_ function definition would be as follows for the _BasicCommunica
 </function>
 ```
 
-### TTS: _OnResetTimeout would be deprecated:_
+### TTS: _OnResetTimeout would be removed:_
 
 ```
-<function name="OnResetTimeout" messagetype="notification" deprecated="true" since="X.Y">
+<function name="OnResetTimeout" messagetype="notification">
 	<description>
 		Sender: HMI->SDL. HMI must send this notification every 10 sec. in case the 'methodName' results long processing on HMI
 	</description>
@@ -106,12 +104,13 @@ _OnResetTimeout_ function definition would be as follows for the _BasicCommunica
 	</param>
 </function>
 ```
+Since HMI API does not support(as i have been told) _deprecated_, we are going to remove the older implementation.
 
-
+**Note**: HMI Integration Guidelines will need to be updated to call out that currently there is no version negotiation between HMI and Core, so older HMI implementations will not work with this new version of Core as UI/TTS _OnResetTimeout_ will be removed.
 
 
 ## Potential downsides
-  * These changes would deprecate OnResetTimeout from _UI_ and _TTS_ interfaces.
+  * These changes would remove OnResetTimeout from _UI_ and _TTS_ interfaces.
 
 ## Impact on existing code
 * HMI API needs to be updated

--- a/proposals/0189-Restructuring-OnResetTimeout.md
+++ b/proposals/0189-Restructuring-OnResetTimeout.md
@@ -109,6 +109,7 @@ Since HMI API does not support deprecated, it is going to be removed from the ol
 
 **Note**: HMI Integration Guidelines will need to be updated to call out that currently there is no version negotiation between HMI and Core, so older HMI implementations will not work with this new version of Core as UI/TTS _OnResetTimeout_ will be removed.
 
+**Note**: Original accepted proposal should be implemented by **not** removing onResetTimeout from UI and TTS for next available release. For release 6.0 though, we should remove onResetTimeout from UI and TTS interfaces.
 
 ## Potential downsides
   * These changes would remove OnResetTimeout from _UI_ and _TTS_ interfaces. As a result, this will cause a major version change to both _HMI API_ and _Core_.

--- a/proposals/0189-Restructuring-OnResetTimeout.md
+++ b/proposals/0189-Restructuring-OnResetTimeout.md
@@ -111,10 +111,10 @@ Since HMI API does not support deprecated, it is going to be removed from the ol
 
 
 ## Potential downsides
-  * These changes would remove OnResetTimeout from _UI_ and _TTS_ interfaces.
+  * These changes would remove OnResetTimeout from _UI_ and _TTS_ interfaces. As a result, this will cause a major version change to both _HMI API_ and _Core_.
 
 ## Impact on existing code
-* HMI API needs to be updated
+* HMI API needs to be updated so that _onResetTimeout_ is removed from _UI_ and _TTS_ interfaces. These changes would be made to _HMI API_ and _Core_ for a new major version. Till then these _functions_ would still be supported.
 * SDL core needs to be updated
 
 ## Alternatives considered


### PR DESCRIPTION
# Revise SDL-0189 to remove UI/TTS OnResetTimeout and remove range for requested

* Altered Proposal: [SDL-0189](0189-Restructuring-OnResetTimeout.md)
* Author: [Ankur Tiwari](https://github.com/ATIWARI9)
* Status: **Accepted with Revisions**
* Impacted Platforms: [Core / RPC]

## Introduction

It was noted in [this](https://github.com/smartdevicelink/sdl_evolution/issues/556#issuecomment-407786014) comment that:
> Lastly, it was noted that details of deprecating an HMI API will be determined upon implementation.

But while trying to implement this proposal it was brought to attention that _keywords "since" and "deprecated" are introduced  to mobile API only, not applicable to HMI API"_.

Also, _requestID_ param needs update as during implementation it is found that _requestID_ (same as correlation_id) is 32 bit unsigned integer.

## Motivation

We need to update the API as per proposed implementation for _OnResetTimeout_


## Proposed solution

* To remove _UI/TTS_ _OnResetTimeout_ from _HMI_API_ as it has already been noted that older HMI implementations would not work with this change.
* To remove range from _requestID_ param so that it conforms to range for unsigned 32bit signed Integer.


## Potential downsides

* Nothing that has not been noted in original proposal.

## Impact on existing code

* Same as original proposal as this change is being worked on currently.

## Alternatives considered

* Keep the _UI/TTS_ _OnResetTimeout_
  * This might cause confusion for HMI implementation. 
  
