### PR TITLE
Support for Android custom RouterService

### DIFF
--- a/proposals/NNNN-support-for-android-custom-routerservice.md
+++ b/proposals/NNNN-support-for-android-custom-routerservice.md
@@ -55,7 +55,7 @@ To improve the connectivity of custom RouterService, the approach would be:
 
 3. We can reuse the existing logic that verifies the trusted RouterService. If a RouterService is not trusted, SdlProxy can wake up the best possible RouterService in the same way the current proxy does. 
 
-In approach #1, the important point is the location where the RouterService's primary transport connects with the head unit. It should be the RouterServiceValidator class.
+In approach #1, the important point is the location where the RouterService's primary transport connects with the head unit. It should be in the RouterServiceValidator class.
 
 ### RouterServiceValidator should pay attention to currently connected RouterService.
 

--- a/proposals/NNNN-support-for-android-custom-routerservice.md
+++ b/proposals/NNNN-support-for-android-custom-routerservice.md
@@ -35,7 +35,7 @@ This proposal is to improve the connectivity for custom RouterService to work wi
 Currently SdlProxy identifies the RouterService in three steps:
 
 1. SdlBroadcastReceiver class has a public method called queryForConnectedService, which finds the RouterService whose primary transport connects with SDL Core. This step also pays attention to if the RouterService is trusted one or not.
-    -  Internally, this binds with RouterService one by one and asks if its primary transport has connection with head unit. So takes some time, and the cost depends on how many SDL apps exist in the device.
+    -  Internally, this binds with RouterService one by one and asks if its primary transport has connection with head unit. So it takes some time, and the cost depends on how many SDL apps exist in the device.
 2. If the step#1 fails, then SdlProxy wakes up the best possible RouterService.
     -  Internally, SdlProxy has the priority order, the latest (which means having the newest version) non-custom RouteService has the priority.
 3. Before the app binds with the RouterService, it verifies that the RouterService is trusted one. If not, then the app falls back to legacy Bluetooth mode.
@@ -46,12 +46,12 @@ Step #1 actually depends on the timing when an app calls queryForConnectedServic
 ## Proposed solution
 
 Suppose a custom RouterService is basically designed for OEM-specific head unit, and the head unit works only with that specific custom RouterService.
-The current logic in previous section does not work very well with custom RouterService, because it heavily depends on the timing when the app calls SdlBroadcastReceiver#queryForConnectedService.
+The current logic in previous section does not work very well in this scenario, because it heavily depends on the timing when the app calls SdlBroadcastReceiver#queryForConnectedService.
 To improve the connectivity of custom RouterService, the approach would be:
 
 1. Do not rely on user app to call queryForConnectedService; instead, SdlProxy should automatically checks to see the RouterService that connects with SDL Core whenever needed.
 
-2. Custom RouterService can not rely on other apps wake up the custom RouterService, because of its priority order. Instead, it needs to start RouterService by himself.
+2. Custom RouterService can not rely on other apps to be waken up, because of its priority order. Instead, it needs to start RouterService by himself.
 
 3. We can reuse the existing logic that verifies the trusted RouterService. If a RouterService is not trusted, SdlProxy can wake up the best possible RouterService in the same way as current proxy does. 
 

--- a/proposals/NNNN-support-for-android-custom-routerservice.md
+++ b/proposals/NNNN-support-for-android-custom-routerservice.md
@@ -41,7 +41,7 @@ Currently SdlProxy identify the RouterService in three steps:
 3. Before the app actually binds with the RouterService, it has validation logic, and the RouterService must be trusted RouterService. If the validation fails. then the app fails to find the trusted RouterService, and fallback to legacy Bluetooth mode.
 
 The problem is that step #2 and #3 unlikely find the custom RouterService, because custom RouterService is lowest order.
-Step #1 actually depends on the timing when the app calls queryForConnectedService. It is up to the application that when to calls queryForConnectedService, but [the integration-basic document] (https://smartdevicelink.com/en/guides/android/getting-started/integration-basics/) suggests it should be called at Activitiy onCreate.
+Step #1 actually depends on the timing when the app calls queryForConnectedService. It is up to the application that when to calls queryForConnectedService, but [the integration-basic document](https://smartdevicelink.com/en/guides/android/getting-started/integration-basics/) suggests it should be called at Activitiy onCreate.
 
 ## Proposed solution
 

--- a/proposals/NNNN-support-for-android-custom-routerservice.md
+++ b/proposals/NNNN-support-for-android-custom-routerservice.md
@@ -26,7 +26,7 @@ Currently, AndroidManifest.xml can indicate the application has a custom RouterS
 ```
 
 When a SDL application determines which RouterService to bind with, the app creates a list of SDL enabled apps, and checks to see if a RouterService transport connects with the head unit.
-If a custom RouterService is already connected with a head unit, and if a SDL application can identify the RouterService correctly, the app should work fine. However, if not, the application instantiates "possibly the best" RouterService. In this case, the custom RouterService is less likely chosen, because the custom RouterService has lower priority than the non-custom RouterService.
+If a custom RouterService is already connected with a head unit, and if a SDL application can identify the RouterService correctly, then the app should work fine. However, if not, the application instantiates "possibly the best" RouterService. In this case, the custom RouterService is less likely chosen, because the custom RouterService has lower priority than the non-custom RouterService.
 If the custom RouterService is the only RouterService that connects with OEM-specific head unit, and the custom RouterService does not connect, the SDL app is unlikely to find the custom RouterService; which means it is unlikely to register with SDL Core.
 This proposal is to improve the connectivity for custom RouterService to work with OEM-specific head units.
 

--- a/proposals/NNNN-support-for-android-custom-routerservice.md
+++ b/proposals/NNNN-support-for-android-custom-routerservice.md
@@ -45,7 +45,7 @@ Step #1 actually depends on the timing of when the app calls queryForConnectedSe
 
 ## Proposed solution
 
-Suppose a custom RouterService is basically designed for OEM-specific head unit, and the head unit works only with that specific custom RouterService.
+Suppose a custom RouterService is basically designed for OEM-specific head units, and the head unit only works with that specific custom RouterService.
 The current logic in the previous section does not work very well in this scenario, because it heavily depends on the timing of when the app calls SdlBroadcastReceiver.queryForConnectedService.
 To improve the connectivity of custom RouterService, the approach would be:
 

--- a/proposals/NNNN-support-for-android-custom-routerservice.md
+++ b/proposals/NNNN-support-for-android-custom-routerservice.md
@@ -59,7 +59,7 @@ In approach #1, the important point is the location where the RouterService's pr
 
 ### RouterServiceValidator should pay attention to currently connected RouterService.
 
-The expected time to check if a RouterService connects with head unit would be right before the app binds with the RouterService, and that should be done automatically without relying on user application.
+The expected time to check if a RouterService connects with head unit would be right before the app binds with the RouterService - this should be done automatically without relying on user application.
 The proposed solution is to add new asynchronous method to RouterServiceValidator, and call it right before the TransportManager connects to the RouterService.
 
 #### Detailed design of asynchronous method
@@ -164,11 +164,12 @@ The pseudo-code of FindRouterTask will be:
 						public void onConnectionStatusUpdate(boolean connected, ComponentName service, Context context) {
 							if (connected) {
 								if (mCallback != null) {
+									RouterServiceValidator.this.service = service;
 									mCallback.onFound(service);
 								}
 							} else {
 								Log.d(TAG, "SdlRouterStatusProvider returns service=" + service + "; connected=" + connected);
-								if (isLast && mCallback != null) {
+								if (isLast && mCallback != null && RouterServiceValidator.this.service == null) {
 									mCallback.onFailed();
 								}
 							}


### PR DESCRIPTION
This proposal is to improve the case where SDL application needs to work with custom RouterService. The definition of custom RouterService is varied, but this proposal refers to the case where a head unit requires an OEM-specific app that works as a RouterService. For instance, if an OEM uses specific Bluetooth server UUID that differs from SDL standard's one, that should be custom RouterService.