### PR TITLE
revision to SDL-0221 - Remote Control - Allow Multiple Modules per Module Type

### DIFF
--- a/proposals/0221-multiple-modules.md
+++ b/proposals/0221-multiple-modules.md
@@ -6,7 +6,7 @@
 * Impacted Platforms: [Core / iOS / Java Suite / RPC]
 
 ## Introduction
-SDL remote control baseline proposal [SDL-0071](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0071-remote-control-baseline.md) groups available controllable items of the same category into a RC module type. SDL defines six module types: `RADIO`, `CLIMATE`, `AUDIO`, `LIGHT`, `HMI_SETTINGS` and `SEAT`. SDL allows only one module per module type so far. However, there are production needs to support multiple modules of the same module type. For example, some vehicles in the market are equipped with "dual-zone" climate control systems. There are also ["tri-zone" or even "quad-zone" climate control](https://www.autotrader.com/car-info/definitions-dual-zone-climate-control-211783) in the existing vehicles. Some vehicles in the market have seat control for several seats (driver's seat, front passenger's seat for example). Some vehicles have both a default entertainment system and a back seat entertainment system. There are car headrest monitors, seat back monitors, car roof mount monitors and flip down screens. Passengers can use a back seat entertainment system to play video, audio or even games. 
+SDL remote control baseline proposal [SDL-0071](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0071-remote-control-baseline.md) groups available controllable items of the same category into a RC module type. SDL defines six module types: `RADIO`, `CLIMATE`, `AUDIO`, `LIGHT`, `HMI_SETTINGS` and `SEAT`. SDL allows only one module per module type so far. However, there are production needs to support multiple modules of the same module type. For example, some vehicles in the market are equipped with "dual-zone" climate control systems. There are also ["tri-zone" or even "quad-zone" climate control](https://www.autotrader.com/car-info/definitions-dual-zone-climate-control-211783) in the existing vehicles. Some vehicles in the market have seat control for several seats (driver's seat, front passenger's seat for example). Some vehicles have both a default entertainment system and a back seat entertainment system. There are car headrest monitors, seat back monitors, car roof mount monitors and flip down screens. Passengers can use a back seat entertainment system to play video, audio or even games.
 
 
 
@@ -37,13 +37,13 @@ This proposal adds a new optional parameter `ModuleInfo` to the existing data st
 </struct>
 ```
 
-The `ModuleInfo` serves two purposes. First, its mandatory parameter `moduleId` is used as an ID helper for a RC module within a module type. Second, it has additional information about the RC module. 
+The `ModuleInfo` serves two purposes. First, its mandatory parameter `moduleId` is used as an ID helper for a RC module within a module type. Second, it has additional information about the RC module.
 
-`location` indicates where the module is located. 
+`location` indicates where the module is located. If `location` does not exist, it does not have a default value.
 
-`serviceArea` indicates the service area or the coverage area of a module. For example, a seat control covers only one seat. The location and the service area of a seat control module are the same. A radio control serves all passengers in the vehicle. Its service area will cover its own physical location as well as other locations in the vehicle.  If a `serviceArea` is not included, it is assumed the `serviceArea` is the same as `location`. If both are not included, it is assumed that they cover the whole area of the vehicle.
+`serviceArea` indicates the service area or the coverage area of a module. For example, a seat control covers only one seat. The location and the service area of a seat control module are the same. A radio control serves all passengers in the vehicle. Its service area will cover its own physical location as well as other locations in the vehicle.  If a `serviceArea` is not included, it is assumed the `serviceArea` is the same as `location`. If both are not included, it is assumed that the `serviceArea` covers the whole area of the vehicle.
 
-Flag `allowMultipleAccess` indicates whether a RC module can be accessed by multiple users or exclusively used by a user. In general, examples of shared module types are `RADIO`, `AUDIO`, `LIGHT` and `HMI`. An example of exclusive module types is `SEAT`. Depending on single climate zone or multiple climate zone support, a module with `CLIMATE` module type can be shared or exclusive.
+Flag `allowMultipleAccess` indicates whether a RC module can be accessed by multiple users or exclusively used by a user. In general, examples of shared module types are `RADIO`, `AUDIO`, `LIGHT` and `HMI`. An example of exclusive module types is `SEAT`. Depending on single climate zone or multiple climate zone support, a module with `CLIMATE` module type can be shared or exclusive. `allowMultipleAllow` is defined per module, not per module type.
 
 It is suggested that the HMI always includes all parameters in capabilities even if they are defined as optional.
 
@@ -78,11 +78,11 @@ The `moduleId` is defined as optional in order to keep backward compatibility. I
 
 In addition, this proposal deprecates the `SupportedSeat` Enumeration and parameter `id` in `SeatControlData` in order to get a uniformed solution.
 
-If a mobile app uses the `SupportedSeat` and no `moduleId` in a RPC request, SDL shall forward the request as is to HMI, HMI shall automatically convert seat `id=DRIVER` to the `moduleId` that corresponds to the driver’s seat module, and seat `id=FRONT_PASSENGER` to the `moduleId` that corresponds to the front passenger's seat.
+If a mobile app uses the `SupportedSeat` `id` and no `moduleId` in a RPC request, SDL shall forward the request as is to HMI, HMI shall automatically convert seat `id=DRIVER` to the `moduleId` that corresponds to the driver’s seat module, and seat `id=FRONT_PASSENGER` to the `moduleId` that corresponds to the front passenger's seat. If a mobile app include both `SupportedSeat` `id` and `moduleId` in a RPC request, `id` shall be ignored since `moduleId` has a higher priority.
 
 ### Define the Grid
 
-This proposal introduces a coordinate system, which divides the space of the vehicle into smaller areas or grids. Each grid has its coordinates (for example column, row in a two-dimensional surface, or column, row and level in a three-dimensional space) and maps to a physical location within or outside a vehicle.  In order to customize the size of the grid, the spans for each dimension are also needed. This proposal assumes left front corner in the bottom level is the origin (0, 0, 0). Negative column/row/level means left/front/bottom outside of the vehicle. 
+This proposal introduces a coordinate system, which divides the space of the vehicle into smaller areas or grids. Each grid has its coordinates (for example column, row in a two-dimensional surface, or column, row and level in a three-dimensional space) and maps to a physical location within or outside a vehicle.  In order to customize the size of the grid, the spans for each dimension are also needed. This proposal assumes left front corner in the bottom level is the origin (0, 0, 0). Negative column/row/level means left/front/bottom outside of the vehicle.
 
 
 ```xml
@@ -126,15 +126,15 @@ The following images and tables show the positions of each seat in popular 7-sea
 
 ![11 or 12 Passenger](../assets/proposals/0221-multiple-modules/4x4.jpg)
 
-| col=-1, row=-1  | col=0 | col=1 | col=2 | col=3 
-| --- | --- | --- | --- | --- | 
+| col=-1, row=-1  | col=0 | col=1 | col=2 | col=3
+| --- | --- | --- | --- | --- |
 | row=0 | driver's seat: 0A  |  |  | front passenger's seat : 0D |
 | row=1 | 1A | 1B |  1C  | |
 | row=2 | 2A | 2B |  2C  | |
 | row=3 | 3A | 3B |  3C  | 3D |
 
 
- The vehicle HMI needs to publish how many rows, columns and levels are available for the vehicle and the list of modules in some properly defined grids. This proposal proposes to publish the row number, column number and level number in a new `SeatLocationCapability`, which also includes all the seats installed and their locations. An app might use this information to show a user a seat map on the mobile device. Note, there is no `id` parameter defined here. 
+ The vehicle HMI needs to publish how many rows, columns and levels are available for the vehicle and the list of modules in some properly defined grids. This proposal proposes to publish the row number, column number and level number in a new `SeatLocationCapability`, which also includes all the seats installed and their locations. An app might use this information to show a user a seat map on the mobile device. Note, there is no `id` parameter defined here.
 
 
 ```xml
@@ -171,14 +171,14 @@ SDL core and HMI shall treat a missing moduleId (older version API) as the defau
 
 - Remote control capabilities
 
-HMI shall always provide a moduleId and service area in the capabilities when it supports multiple modules per module type. 
+HMI shall always provide a moduleId and service area in the capabilities when it supports multiple modules per module type.
 
 - GetInteriorVehicleData/SetInteriorVehicleData request and response
 
-If the optional moduleId is provided in a `GetInteriorVehicleData`/`SetInteriorVehicleData` request, SDL core shall either forward the request to HMI if it is a valid moduleId or reject the request if it is an invalid moduleId. 
+If the optional moduleId is provided in a `GetInteriorVehicleData`/`SetInteriorVehicleData` request, SDL core shall either forward the request to HMI if it is a valid moduleId or reject the request if it is an invalid moduleId.
 
 
-If the optional moduleId is not provided in a `GetInteriorVehicleData`/`SetInteriorVehicleData` request, and if there is at least one module (published by capabilities) of the same module type, SDL core shall use the default `moduleId` (the first item) when processing the request. 
+If the optional moduleId is not provided in a `GetInteriorVehicleData`/`SetInteriorVehicleData` request, and if there is at least one module (published by capabilities) of the same module type, SDL core shall use the default `moduleId` (the first item) when processing the request.
 
 In all cases, HMI/SDL must always include a moduleId in the response even if it is optional and only change/return the data for the requested moduleId. SDL core shall cache the module data for this moduleId + moduleType and forward the response to the mobile.
 
@@ -222,10 +222,7 @@ HMI API is similar to but not the same as the mobile API.
 <struct name="ClimateControlCapabilities" since="4.5">
     <description>Contains information about a climate control module's capabilities.</description>
 -   <!-- need an ID in the future -->
-    <param name="moduleName" type="String" maxlength="100" mandatory="true">
-        <description>The short friendly name of the climate control module.
-            It should not be used to identify a module by mobile application.</description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
@@ -235,12 +232,7 @@ HMI API is similar to but not the same as the mobile API.
 <struct name="RadioControlCapabilities" since="4.5">
     <description>Contains information about a radio control module's capabilities.</description>
 -   <!-- need an ID in the future -->
-    <param name="moduleName" type="String" maxlength="100" mandatory="true">
-        <description>
-            The short friendly name of the climate control module.
-            It should not be used to identify a module by mobile application.
-        </description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
@@ -249,9 +241,7 @@ HMI API is similar to but not the same as the mobile API.
 
 <struct name="ButtonCapabilities" since="1.0">
     <description>Contains information about a button's capabilities.</description>
-    <param name="name" type="ButtonName" mandatory="true">
-        <description>The name of the button. See ButtonName.</description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
@@ -259,12 +249,7 @@ HMI API is similar to but not the same as the mobile API.
 </struct>
 
 <struct name="AudioControlCapabilities" since="5.0">
-    <param name="moduleName" type="String" maxlength="100" mandatory="true">
-        <description>
-            The short friendly name of the light control module.
-            It should not be used to identify a module by mobile application.
-        </description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
@@ -272,12 +257,7 @@ HMI API is similar to but not the same as the mobile API.
 </struct>
 
 <struct name="HMISettingsControlCapabilities" since="5.0">
-    <param name="moduleName" type="String" maxlength="100" mandatory="true">
-        <description>
-          The short friendly name of the HMI setting module.
-          It should not be used to identify a module by mobile application.
-        </description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
@@ -286,25 +266,15 @@ HMI API is similar to but not the same as the mobile API.
 
 
 <struct name="LightControlCapabilities" since="5.0">
-    <param name="moduleName" type="String" maxlength="100" mandatory="true">
-        <description>
-            The short friendly name of the light control module.
-            It should not be used to identify a module by mobile application.
-        </description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
     ...
-</struct>   
-    
+</struct>
+
 <struct name="SeatControlCapabilities" since="5.0">
-    <param name="moduleName" type="String" maxlength="100"  mandatory="true">
-        <description>
-        The short friendly name of the light control module.
-        It should not be used to identify a module by mobile application.
-        </description>
-    </param>
+    ...
 +   <param name="moduleInfo" type="ModuleInfo" mandatory="false" since="5.x">
 +      <description>Information about a RC module, including its id. <description>
 +   </param>
@@ -335,18 +305,7 @@ HMI API is similar to but not the same as the mobile API.
 +   <param name="moduleId" type="String" maxlength="100" mandatory="false" since="5.x">
 +      <description>Id of a module, published by System Capability. <description>
 +   </param>
-    <param name="radioControlData" type="RadioControlData" mandatory="false">
-    </param>
-    <param name="climateControlData" type="ClimateControlData" mandatory="false">
-    </param>
-    <param name="seatControlData" type="SeatControlData" mandatory="false" since="5.0">
-    </param>
-    <param name="audioControlData" type="AudioControlData" mandatory="false" since="5.0">
-    </param>
-    <param name="lightControlData" type="LightControlData" mandatory="false" since="5.0">
-    </param>
-    <param name="hmiSettingsControlData" type="HMISettingsControlData" mandatory="false" since="5.0">
-    </param>
+    ...
 </struct>
 
 <function name="GetInteriorVehicleData" functionID="GetInteriorVehicleDataID" messagetype="request" since="4.5">
@@ -377,12 +336,7 @@ HMI API is similar to but not the same as the mobile API.
 </function>
 
 <enum name="SystemCapabilityType" since="4.5">
-    <description>Enumerations of all available system capability types</description>
-    <element name="NAVIGATION"/>
-    <element name="PHONE_CALL"/>
-    <element name="VIDEO_STREAMING"/>
-    <element name="REMOTE_CONTROL"/>
-    <element name="APP_SERVICES" since="5.1"/>
+    ...
 +   <element name="SEAT_LOCATION" since="5.x"/>
 </enum>
 
@@ -397,11 +351,11 @@ HMI API is similar to but not the same as the mobile API.
     <description>Contains information about the locations of each seat</description>
     <param name="rows" type="Integer" minvalue="1" maxvalue="100" mandatory="false">
     <param name="columns" type="Integer" minvalue="1" maxvalue="100" mandatory="false">
-    <param name="levels" type="Integer" minvalue="1" maxvalue="100" defValue="1" mandatory="false">   
+    <param name="levels" type="Integer" minvalue="1" maxvalue="100" defValue="1" mandatory="false">
     </param>
-+    <param name="seats" type="SeatLocation" array="true" mandatory="false">
-+        <description>Contains a list of SeatLocation in the vehicle</description>
-+    </param>
+    <param name="seats" type="SeatLocation" array="true" mandatory="false">
+        <description>Contains a list of SeatLocation in the vehicle, the first element is the driver's seat</description>
+    </param>
 </struct>
 
 <struct name="SeatLocation" since="5.x">
@@ -415,6 +369,7 @@ HMI API is similar to but not the same as the mobile API.
 The following HMI API needs an update and needs to be added to mobile API.
 
 ```xml
+<interface name="RC" version="2.0.0" date="2018-09-05">
 <function name="GetInteriorVehicleDataConsent" messagetype="request">
 -    <description>Sender: SDL->HMI. </description>
     <description>HMI is expected to display a permission prompt to the driver showing the RC module and app details (for example, app's name).
@@ -425,16 +380,13 @@ The following HMI API needs an update and needs to be added to mobile API.
 +   <param name="moduleIds" type="String" maxlength="100" array="true" mandatory="false">
 +      <description>Ids of a module of same type, published by System Capability. <description>
 +   </param>
-+    <param name="userLocation" type="SeatLocation" mandatory="false">
-+      <description>Location of the user's seat. <description>
-+   </param>
     <param name="appID" type="Integer" mandatory="true">
       <description>ID of the application that triggers the permission prompt.</description>
     </param>
 </function>
-<function name="GetInteriorVehicleDataConsent" messagetype="response">    
+<function name="GetInteriorVehicleDataConsent" messagetype="response">
     <param name="allowed" type="Boolean" array="true" mandatory="true">
-      <description>This array has the same size as "moduleIds" in the request; each element corresponding to one moduleId 
+      <description>This array has the same size as "moduleIds" in the request; each element corresponding to one moduleId
       "true" - if the driver grants the permission for controlling the named app;
       "false" - in case the driver denies the permission for controlling the named app.</description>
     </param>
@@ -446,11 +398,39 @@ The following HMI API needs an update and needs to be added to mobile API.
         </param>
     </histroy>
 </function>
+
+<function name="SetGlobalProperties" messagetype="request">
+    <description>Sets some properties for the application initiated request.</description>
+    <param name="userLocation" type="SeatLocation" mandatory="false">
+        <description>Location of the user's seat. Default is driver's seat location if it is not set yet.</description>
+    </param>
+    <param name="appID" type="Integer" mandatory="true">
+        <description>ID of application related to this RPC.</description>
+    </param>
+</function>
+<function name="SetGlobalProperties" messagetype="response">
+</function>
+</interface>
 ```
 
 Mobile version
 
 ```xml
+<function name="SetGlobalProperties" functionID="SetGlobalPropertiesID" messagetype="request" since="1.0">
+    ...
+    <param name="userLocation" type="SeatLocation" mandatory="false" since="x.x">
+        <description>Location of the user's seat. Default is driver's seat location if it is not set yet.</description>
+    </param>
+</function>
+
+
+<enum name="GlobalProperty" since="1.0">
+    ...
+    <element name="USER_LOCATION" since="x.x">
+        <description>Location of the user's seat of setGlobalProperties</description>
+    </element>
+</enum>
+
 <function name="GetInteriorVehicleDataConsent" functionID="GetInteriorVehicleDataConsentID" messagetype="request" since="5.x">
     <param name="moduleType" type="ModuleType" mandatory="true">
       <description>The module type that the app requests to control.</description>
@@ -458,15 +438,12 @@ Mobile version
     <param name="moduleIds" type="String" maxlength="100" array="true" mandatory="true">
       <description>Ids of a module of same type, published by System Capability. <description>
    </param>
-    <param name="userLocation" type="SeatLocation" mandatory="false">
-      <description>Location of the user's seat. <description>
-    </param>
 </function>
 
 <function name="GetInteriorVehicleDataConsent" functionID="GetInteriorVehicleDataConsentID" messagetype="response" since="5.x">
     <param name="allowed" type="Boolean" array="true" mandatory="true">
-        <description>This array has the same size as "moduleIds" in the request; each element corresponding to one moduleId  
-		"true" - if SDL grants the permission for the requested module;
+        <description>This array has the same size as "moduleIds" in the request; each element corresponding to one moduleId
+        "true" - if SDL grants the permission for the requested module;
         "false" - SDL denies the permission for the requested module.</description>
     </param>
     <param name="resultCode" type="Result" platform="documentation" mandatory="true">
@@ -491,7 +468,7 @@ Mobile version
 </function>
 ```
 
-An alternative solution is to add a new RPC `SetUserLocation`, which is sent from mobile apps to SDL and forwarded to HMI, instead of including `userLocation` as a parameter of the `GetInteriorVehicleDataConsent` RPC.
+An alternative solution is to add a new optional parameter `userLocation` to three RPCs `GetInteriorVehicleDataConsent`, `ButtonPress` and `SetInteriorVehicleData`, which are sent from an mobile app to SDL and forwarded to HMI, instead of including `userLocation` as a parameter of the `SetGlobalProperties` RPC.
 
 
 ### How to use the new parameter for permission control
@@ -500,17 +477,19 @@ A simple Module Id based permission control is listed here.
 
 - SDL shall enforce permission control. It may or may not use the local policy table depending on the implementation. The permissions are given by the user/driver via HMI, and information is passed to sdl core.
 
-- When a user launches a RC app from a phone, the app calls GetSystemCapabilites to get vehicle configurations, which includes how many rows, columns and levels are available, how many / what type / what id of remote control modules are available, and where  those modules are located and/or designed for. With this info, the app may show a map to the user so that user knows where the control modules of each type are, and where the user sits. The app may ask the user to choose their seat location (at least driver or passenger for dismissal of the lock screen) for later use. The app may get this information from other means, for example scan a RFID tag, a NFC chip or a QrCode. The user can choose a RC module or modules for remote control. 
+- When a user launches a RC app from a phone, the app calls GetSystemCapabilites to get vehicle configurations, which includes how many rows, columns and levels are available, how many / what type / what id of remote control modules are available, and where those modules are located and/or designed for. With this info, the app may show a map to the user so that user knows where the control modules of each type are, and where the user sits. The app may ask the user to choose their seat location (at least driver or passenger for dismissal of the lock screen) for later use. The app may get this information from other means, for example scan a RFID tag, a NFC chip or a QrCode. The user can choose a RC module or modules for remote control.
 
-- `GetInteriorVehicleDataConsent` needs be extended to mobile API, so that an app can send a request to control/reserve a RC module after getting the SystemCapabilites and user's intent. 
+- `SetGlobalProperties` needs to be extended to include an optional parameter `userLocation`. The default `userLocation` should be DRIVER's seat to ensure backwards compatibility. Even if the driver's seat is out of the service area of a module, driver's app is still able to control any free module that is allowed by policy.
+
+- `GetInteriorVehicleDataConsent` needs be extended to mobile API, so that an app can send a request to control/reserve a RC module after getting the SystemCapabilites and user's intent.
 
 - Once SDL receives a `GetInteriorVehicleDataConsent`, `SetInteriorVehicleData` or `ButtonPress`, if the requested RC module is exclusive to a user (`allowMultipleAccess=false`), without asking the driver, SDL shall grant the access only if the user's grid equals to or is within module service area. (The reason behind this is that a user shall be able to control his own seat without asking driver's permission; it does not make sense if a pop up is shown on driver's screen). Otherwise, SDL rejects the request.
 
 - If the requested RC module is shared among multiple users (`allowMultipleAccess=true`), all users located within the module's service area can potentially control the module without asking driver's permission.
-  - If the RC setting is auto deny (always no), then only the first user can control the module. Whoever requests a free shared module can lock the module and use it until the user frees the module. 
-  - If the RC setting is auto allow (always yes), then every user can control the module. 
-  - If the RC setting is ask driver, SDL shall grant or deny the request following the current resource allocation rules: if a module is free, allow access; if the module is used by another app, and current app is in HMI FULL, SDL shall trigger or forward `GetInteriorVehicleDataConsent` to HMI. HMI shows a popup so that the driver can give permission to the app for accessing the requested module and options to switch to two other RC settings. (4 options: yes/no/always yes/always no)
-  - In order to reduce driver distractions, the default setting shall be auto allow (always yes). 
+  - If the `accessMode` is `AUTO_DENY` (always no), then only the first user can control the module. Whoever requests a free shared module can lock the module and use it until the user frees the module.
+  - If the `accessMode` is `AUTO_ALLOW` (always yes), then every user can control the module.
+  - If the `accessMode` is `ASK_DRIVER`, SDL shall grant or deny the request following the current resource allocation rules: if a module is free, allow access; if the module is used by another app, and current app is in HMI FULL, SDL shall trigger or forward `GetInteriorVehicleDataConsent` to HMI. HMI shows a popup so that the driver can give permission to the app for accessing the requested module and options to switch to two other RC settings. (4 options: yes/no/always yes/always no)
+  - In order to reduce driver distractions, the default setting shall be `AUTO_ALLOW` (always yes).
   - The driver's yes/no decision shall be cached for certain time (30 days default) configurable in ini file.  Later if the same user (identified by device id or MAC address) uses the same app (identified by policy app id), and tries to control the same module (identified by module type and module id), SDL shall use driver's last known decision if asking driver is needed. A cached item is removed if it is older than 30 days by default. Disable RC will clear all cached items.
 
 - A new RPC `ReleaseInteriorVehicleDataModule` is needed to indicate that the app is done with the RC module and no longer needs access to it.
@@ -560,18 +539,18 @@ Not aware from the author.
 
 
 ## Alternatives considered
-There are some alternatives of how to define the new module `Id` parameter without introducing the grid system.  
+There are some alternatives of how to define the new module `Id` parameter without introducing the grid system.
 
 #### Option 1: Duplicate parameters within module control data
 
-This option duplicates all the parameters within a remote control module type with a slightly different name. 
+This option duplicates all the parameters within a remote control module type with a slightly different name.
 
 Take the `temperature` parameter in "single-zone" climate control as an example, we may have two parameters, a `driver side temperature` and a `passenger side temperature` for "dual-zone" climate control. Each parameter is for a climate zone.
 
 In this option, there is no need to identify the module, as there is still only one module per module type. Instead of having one parameter per module and multiple modules, it has multiple parameters in one big module. Additional parameters are added for the new control items.
 
 This option may work for a few parameters. For example, temperature only. However, there may be separate controls for airflow mode and fan speed in each climate control zone. In seat control, each seat has its own complete set of parameters.
-It is not scalable for many parameters.  
+It is not scalable for many parameters.
 
 
 #### Option 2: OEM assigned ID
@@ -606,7 +585,7 @@ Consider a normal passenger vehicle with 2~8 seats. There are one (driver/front 
 
 For vehicles with more (9, 12, 15) seats, there may be four or five rows and four seats per row. It can get complex to give a name to each seat location. The "grid" system will work better. However, it is not common to have a RC module specific to a seat in these vehicles.
 
-We listed the most commonly used names here. 
+We listed the most commonly used names here.
 
 ```xml
 <enum name="ModuleId">
@@ -626,7 +605,7 @@ We listed the most commonly used names here.
 Not all combinations are valid. An OEM shall make sure they publish a valid combination of `ModuleId` for each `moduleType` in `XyzControlCapabilities`. In addition, mobile apps shall only use ids that are published by the remote control capabilities.
 
 #### Option 4: SDLC assigned "module" ID
-Similar to option 3, but module ID includes module type info. It is possible to use module ID alone to identify a module. We listed the most commonly used names as below. 
+Similar to option 3, but module ID includes module type info. It is possible to use module ID alone to identify a module. We listed the most commonly used names as below.
 
 ```xml
 <enum name="ModuleId">
@@ -654,16 +633,16 @@ Potentially, we may have
 <element name="REAR_RIGHT_CLIMATE"/> (in quad-zone climate control , climate moduleType)
 <element name="SECOND_ROW_CLIMATE"/> (in tri-zone or quad-zone climate control , climate moduleType)
 <element name="THIRD_ROW_CLIMATE"/> (? future)
-<element name="DRIVER_SEAT"/> 
+<element name="DRIVER_SEAT"/>
 <element name="FRONT_PASSENGER_SEAT"/>
-<element name="SECOND_ROW_LEFT_SEAT"/> 
+<element name="SECOND_ROW_LEFT_SEAT"/>
 <element name="SECOND_ROW_RIGHT_SEAT"/>
 <element name="SECOND_ROW_MONITOR"/>
 <element name="ROOF_MONITOR"/>
-<element name="SECOND_ROW_LEFT_MONITOR"/> 
+<element name="SECOND_ROW_LEFT_MONITOR"/>
 <element name="SECOND_ROW_RIGHT_MONITOR"/>
 ```
 
-There is a default module ID per module type. If a request does not specify an ID, either return data from all modules (it is not possible, since the data is not defined as an array, and the system shall not send multiple responses per request) with the same type or data from one default module. 
+There is a default module ID per module type. If a request does not specify an ID, either return data from all modules (it is not possible, since the data is not defined as an array, and the system shall not send multiple responses per request) with the same type or data from one default module.
 
 Unlike option 3, in which there are combinations of moduleInfo and moduleType, this option must predefine all possible module IDs by SDLC.

--- a/proposals/0221-multiple-modules.md
+++ b/proposals/0221-multiple-modules.md
@@ -416,6 +416,16 @@ The following HMI API needs an update and needs to be added to mobile API.
 </function>
 <function name="SetGlobalProperties" messagetype="response">
 </function>
+
+<function name="GetCapabilities" messagetype="response">
+    <param name="remoteControlCapability" type="Common.RemoteControlCapabilities" mandatory="false">
+        <description>See RemoteControlCapabilities, all available RC modules and buttons shall be returned.</description>
+    </param>
++   <param name="seatLocationCapability" type="Common.SeatLocationCapability" mandatory="false">
++       <description>See SeatLocationCapability, all available seat locations shall be returned.</description>
++   </param>
+</function>
+
 </interface>
 ```
 

--- a/proposals/0221-multiple-modules.md
+++ b/proposals/0221-multiple-modules.md
@@ -364,6 +364,12 @@ HMI API is similar to but not the same as the mobile API.
     </param>
 </struct>
 
+<function name="ButtonPress" functionID="ButtonPressID" messagetype="request" since="4.5">
+    ...
++   <param name="moduleId" type="String" maxlength="100" mandatory="false" since="5.x">
++      <description>Id of a module, published by System Capability. <description>
++   </param>
+</function>
 ```
 
 The following HMI API needs an update and needs to be added to mobile API.

--- a/proposals/0221-multiple-modules.md
+++ b/proposals/0221-multiple-modules.md
@@ -202,7 +202,7 @@ app_policies": {
   "xyz app": {
       ....
       "moduleType": ["RADIO", "CLIMATE"],
-      "moduleId": ["id1", "id2", "id3"]
+      "moduleId": [{"id":"id1", "type","RADIO"}, {"id":"id2", "type","RADIO"}, {"id":"id3", "type","CLIMATE"}]
    }
 }
 ```
@@ -484,7 +484,7 @@ Mobile version
 </function>
 ```
 
-An alternative solution is to add a new optional parameter `userLocation` to three RPCs `GetInteriorVehicleDataConsent`, `ButtonPress` and `SetInteriorVehicleData`, which are sent from an mobile app to SDL and forwarded to HMI, instead of including `userLocation` as a parameter of the `SetGlobalProperties` RPC.
+An alternative solution is to add a new optional parameter `userLocation` to four RPCs `GetInteriorVehicleDataConsent`, `ButtonPress`, `GetInteriorVehicleData` and `SetInteriorVehicleData`, which are sent from an mobile app to SDL and forwarded to HMI, instead of including `userLocation` as a parameter of the `SetGlobalProperties` RPC.
 
 
 ### How to use the new parameter for permission control
@@ -547,9 +547,9 @@ Not aware from the author.
 
 ## Impacts on existing code
 
-- New parameters will need to be updated within the RPC.
+- New parameters and/or new RPCs will need to be updated within the RPC.
 
-- SDL core and the mobile proxies will need updates to support the new parameters.
+- SDL core and the mobile proxies will need updates to support the new parameters and RPCs.
 
 - There is no policy change regarding module permission. Policy still controls per module type.
 

--- a/proposals/0221-multiple-modules.md
+++ b/proposals/0221-multiple-modules.md
@@ -43,7 +43,7 @@ The `ModuleInfo` serves two purposes. First, its mandatory parameter `moduleId` 
 
 `serviceArea` indicates the service area or the coverage area of a module. For example, a seat control covers only one seat. The location and the service area of a seat control module are the same. A radio control serves all passengers in the vehicle. Its service area will cover its own physical location as well as other locations in the vehicle.  If a `serviceArea` is not included, it is assumed the `serviceArea` is the same as `location`. If both are not included, it is assumed that the `serviceArea` covers the whole area of the vehicle.
 
-Flag `allowMultipleAccess` indicates whether a RC module can be accessed by multiple users or exclusively used by a user. In general, examples of shared module types are `RADIO`, `AUDIO`, `LIGHT` and `HMI`. An example of exclusive module types is `SEAT`. Depending on single climate zone or multiple climate zone support, a module with `CLIMATE` module type can be shared or exclusive. `allowMultipleAllow` is defined per module, not per module type.
+Flag `allowMultipleAccess` indicates whether a RC module can be accessed by multiple users or exclusively used by a user. In general, examples of shared module types are `RADIO`, `AUDIO`, `LIGHT` and `HMI`. An example of exclusive module types is `SEAT`. Depending on single climate zone or multiple climate zone support, a module with `CLIMATE` module type can be shared or exclusive. `allowMultipleAccess` is defined per module, not per module type.
 
 It is suggested that the HMI always includes all parameters in capabilities even if they are defined as optional.
 
@@ -78,7 +78,7 @@ The `moduleId` is defined as optional in order to keep backward compatibility. I
 
 In addition, this proposal deprecates the `SupportedSeat` Enumeration and parameter `id` in `SeatControlData` in order to get a uniformed solution.
 
-If a mobile app uses the `SupportedSeat` `id` and no `moduleId` in a RPC request, SDL shall forward the request as is to HMI, HMI shall automatically convert seat `id=DRIVER` to the `moduleId` that corresponds to the driver’s seat module, and seat `id=FRONT_PASSENGER` to the `moduleId` that corresponds to the front passenger's seat. If a mobile app include both `SupportedSeat` `id` and `moduleId` in a RPC request, `id` shall be ignored since `moduleId` has a higher priority.
+If a mobile app uses the `SupportedSeat` `id` and no `moduleId` in a RPC request, SDL shall forward the request as is to HMI, HMI shall automatically convert seat `id=DRIVER` to the `moduleId` that corresponds to the driver’s seat module, and seat `id=FRONT_PASSENGER` to the `moduleId` that corresponds to the front passenger's seat. If a mobile app includes both `SupportedSeat` `id` and `moduleId` in a RPC request, `id` shall be ignored since `moduleId` has a higher priority.
 
 ### Define the Grid
 


### PR DESCRIPTION
SDL remote control baseline proposal [SDL-0071](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0071-remote-control-baseline.md) groups available controllable items of the same category into a RC module type. SDL defines six module types: `RADIO`, `CLIMATE`, `AUDIO`, `LIGHT`, `HMI_SETTINGS` and `SEAT`. SDL allows only one module per module type so far. However, there are production needs to support multiple modules of the same module type. For example, some vehicles in the market are equipped with "dual-zone" climate control systems. There are also ["tri-zone" or even "quad-zone" climate control](https://www.autotrader.com/car-info/definitions-dual-zone-climate-control-211783) in the existing vehicles. Some vehicles in the market have seat control for several seats (driver's seat, front passenger's seat for example). Some vehicles have both a default entertainment system and a back seat entertainment system. There are car headrest monitors, seat back monitors, car roof mount monitors and flip down screens. Passengers can use a back seat entertainment system to play video, audio or even games.