### PR TITLE
Revision 0213-rc-radio-climate-parameter-update

### DIFF
--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -67,10 +67,13 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 ...
 -    <param name="availableHDsAvailable" type="Boolean" mandatory="false">
 +    <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.x">
-        <description>
+         <description>
             Availability of the getting the number of available HD channels.
             True: Available, False: Not Available, Not present: Not Available.
-        </description>
+         </description>
++        <history>
++            <param name="availableHDsAvailable" type="Boolean" mandatory="false" since="4.5" until="5.x"/>
++        </history>
     </param>
 +   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.x">
 +       <description>

--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -31,7 +31,7 @@ Add a new parameter `climateEnable` to `ClimateControlData` to allow an applicat
 
 Update `RadioControlCapabilities` and `ClimateControlCapabilities` correspondingly.
 
-In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0. Note that this will require a major version change. Also, this change does not apply to availableHDs because the parameter is being deprecated.
+In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0. Note that this will require a major version change. Also, this change does not apply to availableHDs because the parameter is being deprecated as well as it being a non-mandatory parameter meaning a value of 0 is inferred by its absence.
 
 #### Mobile and HMI API
 

--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -48,7 +48,7 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
         </history>
     </param>
     
-+   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.1">
++   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.x">
 +       <description>the list of available hd sub-channel indexes, empty list means no Hd channel is available, read-only </description>
 +   </param>
     

--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -31,7 +31,7 @@ Add a new parameter `climateEnable` to `ClimateControlData` to allow an applicat
 
 Update `RadioControlCapabilities` and `ClimateControlCapabilities` correspondingly.
 
-In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0. This change does not apply to availableHDs because the parameter is being deprecated.
+In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0. Note that this will require a major version change. Also, this change does not apply to availableHDs because the parameter is being deprecated.
 
 #### Mobile and HMI API
 

--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -40,10 +40,11 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 ...
 <!-- new additions or changes -->
 -   <param name="availableHDs" type="Integer" minvalue="1 maxvalue="7" mandatory="false" since="5.0">
-+   <param name="availableHDs" type="Integer" minvalue="0" maxvalue="7" mandatory="false" deprecated="true" since="5.1">
++   <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" deprecated="true" since="5.x">
         <description>number of HD sub-channels if available</description>
         <history>
             <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
++           <param name="availableHDs" type="Integer" minvalue="1 maxvalue="7" mandatory="false" since="5.0" until="5.x"/>
         </history>
     </param>
     
@@ -52,11 +53,11 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 +   </param>
     
 -    <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
-+    <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="5.1">
++    <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="6.x">
         <description>Current HD sub-channel if available</description>
         <history>
             <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
-+           <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="5.1"/>
++           <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="6.x"/>
         </history>
     </param>
 ...
@@ -65,13 +66,13 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 <struct name="RadioControlCapabilities" since="4.5">
 ...
 -    <param name="availableHDsAvailable" type="Boolean" mandatory="false">
-+    <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.1">
++    <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.x">
         <description>
             Availability of the getting the number of available HD channels.
             True: Available, False: Not Available, Not present: Not Available.
         </description>
     </param>
-+   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.1">
++   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.x">
 +       <description>
 +           Availability of the list of available HD sub-channel indexes.
 +           True: Available, False: Not Available, Not present: Not Available.
@@ -84,7 +85,7 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 
 <struct name="ClimateControlCapabilities" since="4.5">
 ...
-+   <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.1">
++   <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.x">
 +       <description>
 +           Availability of the control of enable/disable climate control.
 +           True: Available, False: Not Available, Not present: Not Available.
@@ -95,7 +96,7 @@ In addition, the minimum index of HD radio sub-channels will need to be changed 
 
 <struct name="ClimateControlData" since="4.5">
 ...
-+    <param name="climateEnable" type="Boolean" mandatory="false" since="5.1">
++    <param name="climateEnable" type="Boolean" mandatory="false" since="5.x">
 +    </param>
 ...
 </struct>
@@ -112,6 +113,7 @@ None
 
 - New parameters will need to be updated within the RPC.
 - SDL core and the mobile proxies will need updates to support the new parameters.
+- Updating the hdChannel minvalue will incur a major version change.
 
 
 ## Alternatives considered

--- a/proposals/0213-rc-radio-climate-parameter-update.md
+++ b/proposals/0213-rc-radio-climate-parameter-update.md
@@ -31,7 +31,7 @@ Add a new parameter `climateEnable` to `ClimateControlData` to allow an applicat
 
 Update `RadioControlCapabilities` and `ClimateControlCapabilities` correspondingly.
 
-In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0.
+In addition, the minimum index of HD radio sub-channels will need to be changed from 1 to 0. This change does not apply to availableHDs because the parameter is being deprecated.
 
 #### Mobile and HMI API
 


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revisions are not to change the behavior of the original proposal, but to correct the API versioning semantics mentioned in the original proposal. The author believes including these changes will require a major version change to the rpc spec. 

# Motivation

To correct the mobile api parameters' versions and history.

# Proposed Solution

- Change deprecated availableHDs  minvalue back to 1. The API should not change the rules for a parameter in the same version that the parameter is being deprecated in.
- Add correct history line to availableHDs.
- Note the `hdChannel` change incurs a major version change.
- Update `since` values to 5.x and 6.x to highlight minor/major api changes.

#### Mobile and HMI API

Note: The updated parameters showing version "5.x" or "6.x" are only representing what the minor or major version changes are. The author is not suggesting the proposal be implemented in separate versions. If it is agreed the proposal should be implemented with a major version change, all new parameters will have the version tag `since="6.x"`.

Author's corrected RPC Spec implementation of the original proposal:
	
```xml
<struct name="RadioControlData" since="4.5">
...
<!-- new additions or changes -->
-   <param name="availableHDs" type="Integer" minvalue="1 maxvalue="7" mandatory="false" since="5.0">
+   <param name="availableHDs" type="Integer" minvalue="1" maxvalue="7" mandatory="false" deprecated="true" since="5.x">
        <description>number of HD sub-channels if available</description>
        <history>
            <param name="availableHDs" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
+           <param name="availableHDs" type="Integer" minvalue="1 maxvalue="7" mandatory="false" since="5.0" until="5.x"/>
        </history>
    </param>
    
+   <param name="availableHdChannels" type="Integer" minvalue="0" maxvalue="7" array="true" minsize="0" maxsize="8" mandatory="false" since="5.x">
+       <description>the list of available hd sub-channel indexes, empty list means no Hd channel is available, read-only </description>
+   </param>
    
-    <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0">
+    <param name="hdChannel" type="Integer" minvalue="0" maxvalue="7" mandatory="false" since="6.x">
        <description>Current HD sub-channel if available</description>
        <history>
            <param name="hdChannel" type="Integer" minvalue="1" maxvalue="3" mandatory="false" since="4.5" until="5.0"/>
+           <param name="hdChannel" type="Integer" minvalue="1" maxvalue="7" mandatory="false" since="5.0" until="6.x"/>
        </history>
    </param>
...
</struct>

<struct name="RadioControlCapabilities" since="4.5">
...
-    <param name="availableHDsAvailable" type="Boolean" mandatory="false">
+    <param name="availableHDsAvailable" type="Boolean" mandatory="false" deprecated="true" since="5.x">
        <description>
            Availability of the getting the number of available HD channels.
            True: Available, False: Not Available, Not present: Not Available.
        </description>
    </param>
+   <param name="availableHdChannelsAvailable" type="Boolean" mandatory="false" since="5.x">
+       <description>
+           Availability of the list of available HD sub-channel indexes.
+           True: Available, False: Not Available, Not present: Not Available.
+       </description>
+   </param>
...
</struct>



<struct name="ClimateControlCapabilities" since="4.5">
...
+   <param name="climateEnableAvailable" type="Boolean" mandatory="false" since="5.x">
+       <description>
+           Availability of the control of enable/disable climate control.
+           True: Available, False: Not Available, Not present: Not Available.
+       </description>
+   </param>
...
</struct>

<struct name="ClimateControlData" since="4.5">
...
+    <param name="climateEnable" type="Boolean" mandatory="false" since="5.x">
+    </param>
...
</struct>

```

# Potential Downsides

Including the change of hdChannel `minvalue=0` will require a major version change. 

# Impact On Existing Code

Changes may affect the original implementations of the proposal slightly. These changes will be reflected mainly in SDL Core/Proxies RPC spec implementation.

# Alternatives Considered
Split proposal across two releases to allow the next RPC spec release to be a minor version change. The breaking change would be blocked until the SDLC thinks it is ready for the next major version change. 