### PR TITLE
Revise 0119-SDL-passenger-mode.md

### DIFF
--- a/proposals/0119-SDL-passenger-mode.md
+++ b/proposals/0119-SDL-passenger-mode.md
@@ -42,23 +42,32 @@ Modify the `OnDriverDistraction` notification:
 
 ### Part 1 - Core
 
-In addition to modifying the notification as shown above, there needs to be an addition to the policy table that feeds into that notification. This way, the OEM can update the ability to allow / disallow this with an update to their policy table.  The exact values used for `lockScreenDismissalEnabled` and `lockScreenDismissalWarning` would be defined by the following new policy table fields in the `module_config` section:
+In addition to modifying the notification as shown above, there needs to be an addition to the policy table that feeds into that notification. This way, the OEM can update the ability to allow / disallow this with an update to their policy table.  The exact values used for `lockScreenDismissalEnabled` and `lockScreenDismissalWarning` would be defined by the following new policy table fields:
 
 ```json
 {
     "policy_table": {
         "module_config": {
             ...
-            "lock_screen_dismissal_enabled": true,
-            "lock_screen_dismissal_warning": {
-                "en-us": "Swipe up to dismiss, acknowledging that you are not the driver",
-                ...
+            "lock_screen_dismissal_enabled": true
+        },
+        ...
+        "consumer_friendly_messages" : {
+            ...
+            "LockScreenDismissalWarning": 
+                "languages": {
+                    "en-us": {
+                        "textBody": "Swipe up to dismiss, acknowledging that you are not the driver"
+                    },
+                    ...
+                }
             }
         }
-        ...
     }
 }
 ```
+
+The `lockScreenDismissalWarning` text would specifically be pulled from the `textBody` field of the appropriate consumer-friendly message (corresponding to the active UI language), all other fields will be ignored.
 
 ### Part 2 - Proxy
 

--- a/proposals/0119-SDL-passenger-mode.md
+++ b/proposals/0119-SDL-passenger-mode.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0119](0119-SDL-passenger-mode.md)
 * Author: [Brett McIsaac](https://github.com/brettywhite)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: iOS, Android, Core, RPC
+* Impacted Platforms: iOS, Android, Core, RPC, Policy Server
 
 ## Introduction
 
@@ -26,21 +26,43 @@ Modify the `OnDriverDistraction` notification:
   <param name="lockScreenDismissalEnabled" type="Boolean" mandatory="false">
     <description>
       If enabled, the lock screen will be able to be dismissed while connected to SDL, allowing users 
-      the ability to interact with the app. Dismissals should include a warning to the user and ensure 
-      that they are not the driver.
+      the ability to interact with the app.
     </description>
   </param>
-
+  <param name="lockScreenDismissalWarning" type="String" mandatory="false">
+    <description>
+      Warning message to be displayed on the lock screen when dismissal is enabled.
+      This warning should be used to ensure that the user is not the driver of the vehicle, 
+      ex. `Swipe up to dismiss, acknowledging that you are not the driver.`.
+      This parameter must be present if "lockScreenDismissalEnabled" is set to true.
+    </description>
+  </param>
 </function>
 ```
 
 ### Part 1 - Core
 
-In addition to modifying the notification as shown above, there needs to be an addition to the policy table that feeds into that notification. This way, the OEM can update the ability to allow / disallow this with an update to their policy table. 
+In addition to modifying the notification as shown above, there needs to be an addition to the policy table that feeds into that notification. This way, the OEM can update the ability to allow / disallow this with an update to their policy table.  The exact values used for `lockScreenDismissalEnabled` and `lockScreenDismissalWarning` would be defined by the following new policy table fields in the `module_config` section:
+
+```json
+{
+    "policy_table": {
+        "module_config": {
+            ...
+            "lock_screen_dismissal_enabled": true,
+            "lock_screen_dismissal_warning": {
+                "en-us": "Swipe up to dismiss, acknowledging that you are not the driver",
+                ...
+            }
+        }
+        ...
+    }
+}
+```
 
 ### Part 2 - Proxy
 
-In addition to modifying the notification, the proposed solution is to have a swipe up gesture to dismiss the lock screen, similar to Android Auto. This will be allowed if `lockScreenDismissalEnabled` is set to `true`, and hidden if set to `false`. If a subsequent notification is received, the lockscreen will re-appear.
+In addition to modifying the notification, the proposed solution is to add a swipe up gesture to dismiss the lock screen (as well as display the provided warning message), similar to Android Auto. This gesture will be allowed if `lockScreenDismissalEnabled` is set to `true`, and disabled if set to `false`. If a subsequent notification is received, the lockscreen will re-appear.
 
 ## Potential downsides
 


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to specify the source of the message that will be displayed to the user to indicate that the lock screen can be dismissed.

# Motivation

To ensure the message displayed via this feature is agreed upon by the SDLC Steering Committee.

# Proposed Solution

Add another parameter to OnDriverDistraction which includes this warning message, defined by the module:

```xml
<function name="OnDriverDistraction" messagetype="notification">
...
  <param name="lockScreenDismissalEnabled" type="Boolean" mandatory="false">
    <description>
      If enabled, the lock screen will be able to be dismissed while connected to SDL, allowing users 
      the ability to interact with the app.
    </description>
  </param>

  <!-- newly added parameter -->
  <param name="lockScreenDismissalWarning" type="String" mandatory="false">
    <description>
      Warning message to be displayed on the lock screen when dismissal is enabled.
      This warning should be used to ensure that the user is not the driver of the vehicle, 
      ex. `Swipe up to dismiss, acknowledging that you are not the driver.`.
      This parameter must be present if "lockScreenDismissalEnabled" is set to true.
    </description>
  </param>
</function>
```

This value could be defined by a new section in `consumer_friendly_messages`:

```json
{
    "policy_table": {
        ...
        "consumer_friendly_messages" : {
            ...
            "LockScreenDismissalWarning": 
                "languages": {
                    "en-us": {
                        "textBody": "Swipe up to dismiss, acknowledging that you are not the driver"
                    },
                    ...
                }
            }
        }
    }
}
```
Only the `textBody` field would be used for the purpose of providing a value for `lockScreenDismissalWarning`.

# Potential Downsides

OEMs would need to ensure that these warning messages are clear and kept up to date.

This would add some complexity to the Core implementation of this feature.

# Impact On Existing Code

All platforms would need to support this new `lockScreenDismissalWarning` field.

Logic would need to be added to Core and the Policy Server for the policy additions described above.

# Alternatives Considered
- Static messages could be created for each supported language and included in the mobile proxies directly, in place of adding the `lockScreenDismissalWarning` field. This would be less flexible, but easier to implement.