### PR TITLE
Revise SDL-0119 SDL Passenger Mode

### DIFF
--- a/proposals/0119-SDL-passenger-mode.md
+++ b/proposals/0119-SDL-passenger-mode.md
@@ -33,7 +33,7 @@ Modify the `OnDriverDistraction` notification:
     <description>
       Warning message to be displayed on the lock screen when dismissal is enabled.
       This warning should be used to ensure that the user is not the driver of the vehicle, 
-      ex. `Swipe up to dismiss, acknowledging that you are not the driver.`.
+      ex. `Swipe down to dismiss, acknowledging that you are not the driver.`.
       This parameter must be present if "lockScreenDismissalEnabled" is set to true.
     </description>
   </param>
@@ -57,7 +57,7 @@ In addition to modifying the notification as shown above, there needs to be an a
             "LockScreenDismissalWarning": 
                 "languages": {
                     "en-us": {
-                        "textBody": "Swipe up to dismiss, acknowledging that you are not the driver"
+                        "textBody": "Swipe down to dismiss, acknowledging that you are not the driver"
                     },
                     ...
                 }
@@ -71,7 +71,7 @@ The `lockScreenDismissalWarning` text would specifically be pulled from the `tex
 
 ### Part 2 - Proxy
 
-In addition to modifying the notification, the proposed solution is to add a swipe up gesture to dismiss the lock screen (as well as display the provided warning message), similar to Android Auto. This gesture will be allowed if `lockScreenDismissalEnabled` is set to `true`, and disabled if set to `false`. If a subsequent notification is received, the lockscreen will re-appear.
+In addition to modifying the notification, the proposed solution is to add a swipe down gesture to dismiss the lock screen (as well as display the provided warning message), similar to Android Auto. This gesture will be allowed if `lockScreenDismissalEnabled` is set to `true`, and disabled if set to `false`. If a subsequent notification is received that changes the `lockScreenDismissalEnabled` parameter, the lockscreen will re-appear.
 
 ## Potential downsides
 


### PR DESCRIPTION
## Introduction
Update SDL-0119 SDL Passenger mode for usability improvements: first, to swipe down instead of up to match most default animations; second, to only show the lock screen again if the dismissal enabled parameter is set to `false` after it had been set to `true`.

## Motivation
The design and usability of this feature on the mobile side is lacking in the current proposal and can be improved.

## Proposed solution
The changes are two part:

1. Change the swipe up gesture to be swipe down. Because iOS and many android phones have a default modal animation of transitioning from the bottom and back to the bottom, a swipe down will follow the movement of the lock screen. This will make more sense to the user than swiping up and the lock screen moving down.

2. Change the re-appearance of the lock screen to only re-appear if both the lock screen becomes required again _and_ the `lockScreenDismissalEnabled` parameter changes to `false`. If the `lockScreenDismissalEnabled` parameter is `true`, and the lock screen has been dismissed, it should remain dismissed. Otherwise, this would lead to a very frustrating user experience for a passenger who is in stop and go traffic as the lock screen will constantly re-appear.

## Potential downsides
1. Android's default animation can vary by phone and may not always be a "from the bottom" modal animation. Therefore the swipe may not always match the animation.

2. If the lock screen was dismissed, it cannot be re-enabled unless the head unit sets the `lockScreenDismissalEnabled` to false.

## Impact on existing code
The mobile libraries will need to be updated

## Alternatives considered
1. Instead of the dismissal persisting until `lockScreenDismissalEnabled` is set to `false`, it could only persist until the device is locked.