### PR TITLE
Revise SDL-0186 Template Titles

### DIFF
--- a/proposals/0186-template-titles.md
+++ b/proposals/0186-template-titles.md
@@ -23,7 +23,7 @@ Basic templates have nothing to orient the user to where they are in the UI. A t
     ...
 
     <!-- New Additions -->
-    <param name="templateTitle" type="String" maxlength="100" mandatory="false">
+    <param name="templateTitle" type="String" minlength="0" maxlength="100" mandatory="false">
         <description>
             The title of the new template that will be displayed. 
             How this will be displayed is dependent on the OEM design and implementation of the template.

--- a/proposals/0186-template-titles.md
+++ b/proposals/0186-template-titles.md
@@ -30,6 +30,15 @@ Basic templates have nothing to orient the user to where they are in the UI. A t
         </description>
     </param>
 </function>
+
+<enum name="TextFieldName" since="1.0">
+    <!-- Existing RPCs -->
+
+    <!-- Additions -->
+    <element name="templateTitle">
+        <description>The template title field in Show</description>
+    </element>
+</enum>
 ```
 
 ## Potential downsides

--- a/proposals/0186-template-titles.md
+++ b/proposals/0186-template-titles.md
@@ -35,7 +35,7 @@ Basic templates have nothing to orient the user to where they are in the UI. A t
     <!-- Existing RPCs -->
 
     <!-- Additions -->
-    <element name="templateTitle">
+    <element name="templateTitle" since="x.x">
         <description>The template title field in Show</description>
     </element>
 </enum>

--- a/proposals/0186-template-titles.md
+++ b/proposals/0186-template-titles.md
@@ -36,7 +36,7 @@ Basic templates have nothing to orient the user to where they are in the UI. A t
 
     <!-- Additions -->
     <element name="templateTitle" since="x.x">
-        <description>The template title field in Show</description>
+        <description>The template title field; applies to "Show"</description>
     </element>
 </enum>
 ```


### PR DESCRIPTION
## Introduction
Update SDL-0186 Template Titles capability improvements by adding a new `TextFieldName` value and permitting the `templateTitle` to be altered by setting it to an empty string.

## Motivation
The design currently provides no support for developers to know the length of the text field available to them. Second, the design should permit removing the title by setting an empty string.

## Proposed solution
The proposed changes are as follows:

```xml
<enum name="TextFieldName" since="1.0">
    <!-- Existing RPCs -->

    <!-- Additions -->
    <element name="templateTitle" since="x.x">
        <description>The template title field in Show</description>
    </element>
</enum>
```

and

```xml
<param name="templateTitle" type="String" minlength="0" maxlength="100" mandatory="false">
```

where the `minlength` has been added.

## Potential downsides
No downsides identified; this is a very small update.

## Impact on existing code
The implementations will have to be updated

## Alternatives considered
No alternatives considered