### PR TITLE
Revise SDL-0108 AutoCompleteList

### DIFF
--- a/proposals/0108-AutoCompleteList.md
+++ b/proposals/0108-AutoCompleteList.md
@@ -23,8 +23,8 @@ The system currently only allows for a single suggestion while using the keyboar
 
 ```xml
 <param name="autoCompleteText" type="String" maxlength="1000" mandatory="false">
-      <description>Allows an app to prepopulate the text field with a suggested or completed entry as the user types</description>
-     </param>
+    <description>Allows an app to prepopulate the text field with a suggested or completed entry as the user types</description>
+</param>
 ```
 
 ### Proposed Implementation:
@@ -32,9 +32,9 @@ The system currently only allows for a single suggestion while using the keyboar
 There is a new parameter for KeyboardProperties which uses an array to allow multiple listing instead of one. 
 
 ```xml
-<param name="autoCompleteList" type="String" maxlength="1000" minsize="1" maxsize="100" array="true" mandatory="false">
-    <description>Allows an app to prepopulate the text field with a list of suggested or completed entry as the user types</description>
- </param>   
+<param name="autoCompleteList" type="String" maxlength="1000" minsize="0" maxsize="100" array="true" mandatory="false">
+    <description>Allows an app to prepopulate the text field with a list of suggested or completed entry as the user types. Set to 0 to remove the auto-complete list from the screen</description>
+</param>   
 ```
 
 If an app send both an autoCompleteText and an autoCompleteList parameter in a request to a HU that supports autoCompleteList, the response is successful, and the autoCompleteText is ignored all together.


### PR DESCRIPTION
## Introduction
Update SDL-0108 AutoCompleteList to support clearing the list.

## Motivation
The current design provides no ability for developers to remove the auto complete list from the screen (e.g. for the next popup or if the user backspaces enough).

## Proposed solution
The proposed change is as follows:

```xml
<!-- Old --> 
<param name="autoCompleteList" type="String" maxlength="1000" minsize="1" maxsize="100" array="true" mandatory="false">
    <description>Allows an app to prepopulate the text field with a list of suggested or completed entry as the user types.</description>
</param> 

<!-- New --> 
<param name="autoCompleteList" type="String" maxlength="1000" minsize="0" maxsize="100" array="true" mandatory="false">
    <description>Allows an app to prepopulate the text field with a list of suggested or completed entry as the user types. Set to 0 to remove the auto-complete list from the screen</description>
</param> 
```

## Potential downsides
No downsides identified; this is a very small update.

## Impact on existing code
The implementations will have to be updated

## Alternatives considered
No alternatives considered