### PR TITLE
SDL 0216 - Widget Support (Revision)

### DIFF
--- a/proposals/0216-widget-support.md
+++ b/proposals/0216-widget-support.md
@@ -663,7 +663,7 @@ After investigating impact to SDL Core, the impact is expected to be minor. Glob
 2. Changes to State Controller to allow HMI level transitions for widgets and windows
 3. Changes to Request Controller as RPCs from one app can be addressed to different windows
 
-Subsequent proposals should define how to refactor managers (ScreenManager and SystemCapabilityManager) to read window capabilities notifications as well as the deprecated parameters.
+Subsequent proposals should define how to refactor managers (ScreenManager and SystemCapabilityManager) to read window capabilities notifications as well as the deprecated parameters. These proposals should also deprecate the Java specific custom system capability types `DISPLAY`, `BUTTON`, `SOFTBUTTON` and `PRESET_BANK`. The proxy library releases including this feature should also include mentioned manager updates to ensure this feature to be easily accessible with the managers from the start.
 
 ## Alternatives considered
 

--- a/proposals/0216-widget-support.md
+++ b/proposals/0216-widget-support.md
@@ -428,7 +428,7 @@ A new system capability type is necessary in order to provide display capabiliti
 
 ```xml
 <enum name="SystemCapabilityType" since="4.5">
-    <element name="DISPLAY" since="5.x" />
+    <element name="DISPLAYS" since="5.x" />
 </enum>
 ```
 
@@ -663,7 +663,7 @@ After investigating impact to SDL Core, the impact is expected to be minor. Glob
 2. Changes to State Controller to allow HMI level transitions for widgets and windows
 3. Changes to Request Controller as RPCs from one app can be addressed to different windows
 
-The window managers should be refactored to read window capabilities notifications as well as the deprecated parameters.
+Subsequent proposals should define how to refactor managers (ScreenManager and SystemCapabilityManager) to read window capabilities notifications as well as the deprecated parameters.
 
 ## Alternatives considered
 

--- a/proposals/0216-widget-support.md
+++ b/proposals/0216-widget-support.md
@@ -663,7 +663,7 @@ After investigating impact to SDL Core, the impact is expected to be minor. Glob
 2. Changes to State Controller to allow HMI level transitions for widgets and windows
 3. Changes to Request Controller as RPCs from one app can be addressed to different windows
 
-Subsequent proposals should define how to refactor managers (ScreenManager and SystemCapabilityManager) to read window capabilities notifications as well as the deprecated parameters. These proposals should also deprecate the Java specific custom system capability types `DISPLAY`, `BUTTON`, `SOFTBUTTON` and `PRESET_BANK`. The proxy library releases including this feature should also include mentioned manager updates to ensure this feature to be easily accessible with the managers from the start.
+Subsequent proposals should define how to refactor managers (ScreenManager and SystemCapabilityManager) to read window capabilities notifications as well as the deprecated parameters. The managers update will include deprecating `DISPLAY` system capability. The proxy library releases including this feature should also include mentioned manager updates to ensure this feature to be easily accessible with the managers from the start.
 
 ## Alternatives considered
 


### PR DESCRIPTION
# Widget Support

* Proposal: [SDL-0216](0216-widget-support.md)
* Author: [Kujtim Shala](https://github.com/kshala-ford)
* Status: **Awaiting review**
* Impacted Platforms: [Core / iOS / Android / RPC ]

## Introduction

This minor revision to the proposal is about renaming an enum value from `DISPLAY` to `DISPLAYS` and describing of subsequent proposals adding manager revisions.

## Motivation

While writing the new proposals that describe the changes to ScreenManager and SystemCapabilityManager the author identified that the enum value clashes with #216 as it already added `DISPLAY` to the `SystemCapabilityType` enum.

## Proposed solution

In order to meet deadlines for the new SDL Core release the `SystemCapabilityType` element `DISPLAY` should be simply renamed to `DISPLAYS`.

```xml
<enum name="SystemCapabilityType" since="4.5">
-    <element name="DISPLAY" since="6.0" />
+    <element name="DISPLAYS" since="6.0" />
</enum>
```

This change would allow creating a subsequent proposal how SystemCapabilityManager and ScreenManager should be changed to read.

## Potential downsides

No downsides identified with the rename.

## Impact on existing code

This proposal avoids impact to existing Java. With the acceptance of this proposal the code to come for widget support will be modified to use `DISPLAYS` as the enum element.

## Alternatives considered

No alternatives are considered.