### PR TITLE
SDL 0231 Menu Tiles Revision

### DIFF
--- a/proposals/0231-main-menu-tiles.md
+++ b/proposals/0231-main-menu-tiles.md
@@ -56,7 +56,7 @@ We will then add the ability to change the menu to a tiled layout using `SetGlob
 <function name="SetGlobalProperties" functionID="SetGlobalPropertiesID" messagetype="request">
     ...
     <!-- Additions -->
-    <param name="menuLayout" type="MenuLayout" defvalue="LIST" mandatory="false" since="X.Y">
+    <param name="menuLayout" type="MenuLayout" mandatory="false" since="X.Y">
         <description>Sets the layout of the main menu screen. If this is sent while a menu is already on-screen, the head unit will change the display to the new layout type.</description>
     </param>
 </function>
@@ -66,7 +66,7 @@ We will then add the ability to change the menu to a tiled layout using `SetGlob
     
     ...
     <!-- Additions -->
-    <param name="menuLayout" type="MenuLayout" defvalue="LIST" mandatory="false" since="X.Y">
+    <param name="menuLayout" type="MenuLayout" mandatory="false" since="X.Y">
         <description>Sets the layout of the submenu screen.</description>
     </param>
 </function>
@@ -99,7 +99,7 @@ The HMI_API updates are very similar to the MOBILE_API updates.
 <function name="UI.SetGlobalProperties" messagetype="request">
     ...
     <!-- Additions -->
-    <param name="menuLayout" type="MenuLayout" defvalue="LIST" mandatory="false">
+    <param name="menuLayout" type="MenuLayout" mandatory="false">
         <description>Sets the layout of the main menu screen. If this is sent while a menu is already on-screen, the head unit will change the display to the new layout type.</description>
     </param>
 </function>
@@ -109,7 +109,7 @@ The HMI_API updates are very similar to the MOBILE_API updates.
     
     ...
     <!-- Additions -->
-    <param name="menuLayout" type="MenuLayout" defvalue="LIST" mandatory="false" since="X.Y">
+    <param name="menuLayout" type="MenuLayout" mandatory="false" since="X.Y">
         <description>Sets the layout of the submenu screen.</description>
     </param>
 </function>


### PR DESCRIPTION
# Introduction

This is a revision to remove the default value (`defvalue="LIST"`) from the menuLayout parameter introduced by the original proposal.

# Motivation

While testing for regressions SetGlobalProperties the author noticed that including a defvalue in the RPC means that any time that the menuLayout parameter is omitted, the menuLayout would be set to LIST. This is problematic if an app had previously set TILES as the menu layout in a previous SetGlobalProperties Request. 

# Proposed Solution

In all mentions of menuLayout, the default value should be removed. This applies to SetGlobalProperties and AddSubMenu requests in the mobile and hmi apis.
```
-    <param name="menuLayout" type="MenuLayout" defvalue="LIST" mandatory="false" since="X.Y">
+    <param name="menuLayout" type="MenuLayout" mandatory="false" since="X.Y">
```

# Potential downsides

No downsides identified with the API change.

# Impact on existing code

Core and mobile will need to update their RPC spec implementations to not include or autofill a default parameter for menuLayout.

# Alternatives considered

Leave the default value as is. The author does not believe this is an ideal solution.