### PR TITLE
[SDL 0173] - Read Generic Network Signal Data Clarification

### DIFF
--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -662,7 +662,7 @@ Here is a sample flow diagram for SDL Core <-> HMI request response model:
             <description>Published data result code.</description>
         </param>
 +        <param name="oemCustomDataType" type="String" mandatory="false" since="6.0">
-+            <description>Type of requested oem specific parameter </description>
++            <description>Type of requested OEM specific parameter </description>
 +        </param>
     </struct>
 ```

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -648,6 +648,41 @@ Consider **gps** as API vehicle data Item, and **HEAD_LAMP_STATUS** as vehicle d
 Here is a sample flow diagram for SDL Core <-> HMI request response model:
 ![SDL-HMI%20request%20response%20flow](../assets/proposals/0173-Read-Generic-Network-Signal-data/SDL-HMI%20request%20response%20flow.png)
 
+#### Subscribe vehicle data result for oemspecific parameters: 
+
+- VehicleDataResult in MOBILE API will be extended with non mandatory parameter `oemCustomDataType` 
+
+```
+   <struct name="VehicleDataResult" since="2.0">
+        <description>Individual published data request result</description>
+        <param name="dataType" type="VehicleDataType" mandatory="true">
+            <description>Defined published data element type.</description>
+        </param>
+        <param name="resultCode" type="VehicleDataResultCode" mandatory="true">
+            <description>Published data result code.</description>
+        </param>
++        <param name="oemCustomDataType" type="String" mandatory="false" since="6.0">
++            <description>Type of requested oem specific parameter </description>
++        </param>
+    </struct>
+```
+
+
+VehicleDataType will be extended with `OEM_VEHICLE_DATA_TYPE` value:
+
+```
+ <enum name="VehicleDataType" since="2.0">
+        <description>Defines the data types that can be published and subscribed to.</description>
+        <element name="VEHICLEDATA_GPS">
+        ...
+        <element name="VEHICLEDATA_CLOUDAPPVEHICLEID" since="5.1"/>
+ +       <element name="VEHICLEDATA_OEM_VEHICLE_DATA_TYPE" since="6.0"/>
+ </enum>
+```
+
+For oem specific parameters, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_VEHICLE_DATA_TYPE`.
+For parameters from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
+
 ## Proxy side changes
 Once core has downloaded and processed the new vehicle data params, it'd send an _onPermissionsChange_ notification to the connected app with new vehicle data params. The App developer would rely on this notification to request new vehicle data items using a generic request/response methods in _GetVehicleData/SubscribeVehicleData/UnsubscribeVehicleData/OnVehicleData_ request and response messages.
 

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -670,6 +670,7 @@ Here is a sample flow diagram for SDL Core <-> HMI request response model:
 
 `VehicleDataResult` in MOBILE API will be extended with non mandatory parameter `oemCustomDataType`
 
+`VehicleDataType` will be extended with `VEHICLEDATA_OEM_VEHICLE_DATA_TYPE` value in HMI and MOBILE APIs.
 ```
  <enum name="VehicleDataType" since="2.0">
         <description>Defines the data types that can be published and subscribed to.</description>

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -670,20 +670,20 @@ Here is a sample flow diagram for SDL Core <-> HMI request response model:
 
 `VehicleDataResult` in MOBILE API will be extended with non mandatory parameter `oemCustomDataType`
 
-`VehicleDataType` will be extended with `VEHICLEDATA_OEM_VEHICLE_DATA_TYPE` value in HMI and MOBILE APIs.
+`VehicleDataType` will be extended with `VEHICLEDATA_OEM_CUSTOM_DATA` value in HMI and MOBILE APIs.
 ```
  <enum name="VehicleDataType" since="2.0">
         <description>Defines the data types that can be published and subscribed to.</description>
         <element name="VEHICLEDATA_GPS">
         ...
         <element name="VEHICLEDATA_CLOUDAPPVEHICLEID" since="5.1"/>
- +       <element name="VEHICLEDATA_OEM_VEHICLE_DATA_TYPE" since="6.0"/>
+ +       <element name="VEHICLEDATA_OEM_CUSTOM_DATA" since="6.0"/>
  </enum>
 ```
 
 
 
-For oem specific custom vehicle data items, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_VEHICLE_DATA_TYPE`.
+For oem specific custom vehicle data items, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_CUSTOM_DATA`.
 For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
 
 ## Proxy side changes

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -648,7 +648,7 @@ Consider **gps** as API vehicle data Item, and **HEAD_LAMP_STATUS** as vehicle d
 Here is a sample flow diagram for SDL Core <-> HMI request response model:
 ![SDL-HMI%20request%20response%20flow](../assets/proposals/0173-Read-Generic-Network-Signal-data/SDL-HMI%20request%20response%20flow.png)
 
-#### Subscribe vehicle data result for oemspecific parameters: 
+#### API changes required for custom vehicle data:
 
 - VehicleDataResult in MOBILE API will be extended with non mandatory parameter `oemCustomDataType` 
 
@@ -668,7 +668,7 @@ Here is a sample flow diagram for SDL Core <-> HMI request response model:
 ```
 
 
-VehicleDataType will be extended with `OEM_VEHICLE_DATA_TYPE` value:
+`VehicleDataResult` in MOBILE API will be extended with non mandatory parameter `oemCustomDataType`
 
 ```
  <enum name="VehicleDataType" since="2.0">
@@ -680,8 +680,10 @@ VehicleDataType will be extended with `OEM_VEHICLE_DATA_TYPE` value:
  </enum>
 ```
 
-For oem specific parameters, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_VEHICLE_DATA_TYPE`.
-For parameters from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
+
+
+For oem specific custom vehicle data items, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_VEHICLE_DATA_TYPE`.
+For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
 
 ## Proxy side changes
 Once core has downloaded and processed the new vehicle data params, it'd send an _onPermissionsChange_ notification to the connected app with new vehicle data params. The App developer would rely on this notification to request new vehicle data items using a generic request/response methods in _GetVehicleData/SubscribeVehicleData/UnsubscribeVehicleData/OnVehicleData_ request and response messages.

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -684,7 +684,7 @@ Here is a sample flow diagram for SDL Core <-> HMI request response model:
 
 
 For OEM specific custom vehicle data items, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_CUSTOM_DATA`.
-For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
+For vehicle data items from RPC Spec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
 
 ## Proxy side changes
 Once core has downloaded and processed the new vehicle data params, it'd send an _onPermissionsChange_ notification to the connected app with new vehicle data params. The App developer would rely on this notification to request new vehicle data items using a generic request/response methods in _GetVehicleData/SubscribeVehicleData/UnsubscribeVehicleData/OnVehicleData_ request and response messages.

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -715,13 +715,13 @@ public VehicleDataResult getOEMCustomVehicleData (String vehicleDataName){
 ```
 public static final String KEY_CUSTOM_DATA_TYPE = "oemCustomDataType";
 
-public VehicleDataResult(@NonNull String oemCustomDataType, @NonNull VehicleDataResultCode resultCode){
+public VehicleDataResult(String oemCustomDataType, @NonNull VehicleDataResultCode resultCode){
 	this();
 	setOEMCustomVehicleDataType(oemCustomDataType);
 	setResultCode(resultCode);
 }
 	
-public void setOEMCustomVehicleDataType(@NonNull String oemCustomDataType) {
+public void setOEMCustomVehicleDataType(String oemCustomDataType) {
 	setValue(KEY_OEM_CUSTOM_DATA_TYPE, oemCustomDataType);
 }
 

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -683,7 +683,7 @@ Here is a sample flow diagram for SDL Core <-> HMI request response model:
 
 
 
-For oem specific custom vehicle data items, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_CUSTOM_DATA`.
+For OEM specific custom vehicle data items, `oemCustomDataType` will contain type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_CUSTOM_DATA`.
 For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.
 
 ## Proxy side changes


### PR DESCRIPTION
## Introduction

* Explicit mention in MOBILE_API new not mandatory parameter oemCustomDataType. This is needed to match [proxy side implementation](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0173-Read-Generic-Network-Signal-data.md#update-vehicledataresult-to-support-custom-vehicle-data-items-by-adding)
* Extending VehicleDataType with additional value VEHICLEDATA_OEM_CUSTOM_DATA in MOBILE and HMI APIs for sending subscription/unsubscription result to mobile. This is clarification detail for following [point in the original proposal(SDL-0173)](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0173-Read-Generic-Network-Signal-data.md#impact-on-existing-code)
 - Remove @nonnull directive from oemCustomDataType parameter in Proxy library since the parameter is optional

## Motivation

The accepted proposal should  explicitly contain API changes.

## Proposed solution
### Technical details 
#### API changes required for custom vehicle data:

- VehicleDataResult in MOBILE API will be extended with non-mandatory parameter `oemCustomDataType` 

```
   <struct name="VehicleDataResult" since="2.0">
        <description>Individual published data request result</description>
        <param name="dataType" type="VehicleDataType" mandatory="true">
            <description>Defined published data element type.</description>
        </param>
        <param name="resultCode" type="VehicleDataResultCode" mandatory="true">
            <description>Published data result code.</description>
        </param>
+        <param name="oemCustomDataType" type="String" mandatory="false" since="6.0">
+            <description>Type of requested oem specific parameter </description>
+        </param>
    </struct>
```


`VehicleDataResult` in MOBILE API will be extended with non-mandatory parameter `oemCustomDataType`

`VehicleDataType` will be extended with `VEHICLEDATA_OEM_CUSTOM_DATA` value in HMI and MOBILE APIs.
```
 <enum name="VehicleDataType" since="2.0">
        <description>Defines the data types that can be published and subscribed to.</description>
        <element name="VEHICLEDATA_GPS">
        ...
        <element name="VEHICLEDATA_CLOUDAPPVEHICLEID" since="5.1"/>
 +       <element name="VEHICLEDATA_OEM_CUSTOM_DATA" since="6.0"/>
 </enum>
```



For OEM specific custom vehicle data items, `oemCustomDataType` will contain a type of OEM specific vehicle data (from schema), and `dataType` will be `VEHICLEDATA_OEM_CUSTOM_DATA`.
For vehicle data items from RPCSpec, `oemCustomDataType` will be omitted, and `dataType` will contain appropriate data type from `VehicleDataType` enum.

### Update VehicleDataResult to support custom vehicle data items by adding:
```
-  public VehicleDataResult(@NonNull String oemCustomDataType, @NonNull VehicleDataResultCode resultCode){ 
+ public VehicleDataResult( String oemCustomDataType, VehicleDataResultCode resultCode){ 
```

```
-  public void setOEMCustomVehicleDataType(@NonNull String oemCustomDataType) { 
+  public void setOEMCustomVehicleDataType(String oemCustomDataType) { 
```

## Potential downsides
N/A Changes clarifies proposal, but not introduce changes 

## Alternatives considered

N/A Changes clarifies proposal, but not introduce changes  

## Impact on existing code

Impacts only Vehicle data subscription commands 