### PR TITLE
Revise SDL-0179 Pixel Density and Scale

### DIFF
--- a/proposals/0179-pixel-density-and-scale.md
+++ b/proposals/0179-pixel-density-and-scale.md
@@ -181,7 +181,7 @@ Alternatively modify `ScreenParams` struct used by `RegisterAppInterfaceResponse
 <param name="pixelPerInch" type="Float" mandatory="false">
  <description>PPI is the diagonal resolution in pixels divided by the diagonal screen size in inches.</description>
 </param>
-<param name="scale" type="Float" mandatory="false">
+<param name="scale" type="Float" minvalue="1" maxvalue="10" mandatory="false">
   <description>The scaling factor the app should use to change the size of the projecting view.</description>
 </param>
 </struct>


### PR DESCRIPTION
# Introduction
Update SDL-0179 Pixel Density and Scale by adding a min and max value for the `scale` parameter in the `VideoStreamingCapability`.

# Motivation
The current implementation allows for zero and negative `scale` values. A min and max value should be added to prevent invalid `scale` values.

# Proposed Solution
The proposed changes are as follows:
```
<param name="scale" type="Float" minvalue="1" maxvalue="10" mandatory="false">
```
The `minvalue` and `maxvalue` were added.

# Potential downsides
No downsides identified; this is a very small update.

# Impact on existing code
The implementations will have to be updated

# Alternatives considered
No alternatives considered
