### PR TITLE
Revise 0173-Read-Generic-Network-Signal-data.md

### DIFF
--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -57,7 +57,7 @@ Instead of validating vehicle data items against APIs XML, SDL core would rely o
 
 The proposed Policy Table structure assumes that SDL core enums are defined in the RPC Spec and are _not_ defined within the Policy Table. 
 
-Additionally if there is a custom data item in the PTU that uses an enum not defined in a modules max supported RPC Spec version, no validation will be performed on this parameter. The impact of this note means that Core will pass custom enum data types it does not recognize as a string to/from the hmi/mobile device.
+Additionally if there is a custom data item in the PTU that uses an enum that is not defined in a module's local RPC Spec, no validation will be performed on this parameter. The impact of this is that Core will pass enum data types it does not recognize as a raw string between the HMI and mobile device.
 
 
 ### Vehicle Data Schema file location and updates

--- a/proposals/0173-Read-Generic-Network-Signal-data.md
+++ b/proposals/0173-Read-Generic-Network-Signal-data.md
@@ -55,7 +55,9 @@ Instead of validating vehicle data items against APIs XML, SDL core would rely o
 * _since_, _until_ are String values and are optional per vehicle data item. _removed_, _deprecated_ are Boolean values and are optional per vehicle data item. _minvalue_, _maxvalue_, _minsize_, _maxsize_, _minlength_, _maxlength_ are Integer values and are optional per vehicle data item.
   * _Custom/OEM Specific_ vehicle data parameters that are not a part of the rpc spec should not have any version related tags included (since, until, removed, deprecated), these vehicle data parameters would not be able to have the same versioning system as the rpc spec since any version number supplied would not be the version associated with any known public rpc spec.
 
-The proposed Policy Table structure assumes that SDL core enums are defined in the RPC Spec and are _not_ defined within the Policy Table.
+The proposed Policy Table structure assumes that SDL core enums are defined in the RPC Spec and are _not_ defined within the Policy Table. 
+
+Additionally if there is a custom data item in the PTU that uses an enum not defined in a modules max supported RPC Spec version, no validation will be performed on this parameter. The impact of this note means that Core will pass custom enum data types it does not recognize as a string to/from the hmi/mobile device.
 
 
 ### Vehicle Data Schema file location and updates


### PR DESCRIPTION
# Introduction

Update 0173-Read-Generic-Network-Signal-data with an implementation detail regarding the  behavior of Core for unknown custom vehicle data enums. Although the author sees this as an implementation detail, this revision is being made for clarity and documentation purposes. 

# Motivation

The proposal outlined details regarding how primitive types and structs should be handled, but did not include a way to handle or define unknown enum types. Currently, Core will reject a PTU which includes an unknown data type/enum in the `vehicle_data` section of the policy table. 

For example, if in a future version of the RPC spec a new enum is introduced:

```
     <enum name="FutureEnum" since="6.1">
        <element name="VERY_FUTURE"/>
        <element name="SLIGHTLY_FUTURE"/>
        <element name="NOT_FUTURE"/>
    </enum>
```

and a policy table update vehicle_data section uses this enum type for a custom data item:

```
                {
                    "name": "newEnum",
                    "key": "OEM_REF_NEW_ENUM",
                    "type": "FutureEnum",
                    "mandatory": false
                },
```

this will cause the PTU to be rejected.

# Proposed Solution

If a PTU includes a custom data item with an unknown enum type, Core should allow this parameter and should not perform any message validation on the enum value. The impact of this detail means that Core will pass custom enum data types it does not recognize as a string to/from the hmi/mobile device.

# Potential Downsides 

Core would not be able to check the enum values for errors / invalid data. This validation would be up to the HMI and mobile proxies.

# Impact on existing code

Only requires changes to Core. No mobile or hmi api changes will be required.

# Alternatives

No other alternatives were identified. To the author this solution is very easy to implement and would be very effective in fixing a discovered issue.
