### PR TITLE
SDL-0234 Proxy Library RPC Generation - Revision

### DIFF
--- a/proposals/0234-proxy-rpc-generation.md
+++ b/proposals/0234-proxy-rpc-generation.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0234](0234-proxy-rpc-generation.md)
 * Author: [Joel Fischer](https://github.com/joeljfischer)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [iOS / Java Suite]
+* Impacted Platforms: [iOS / Java Suite / JavaScript ]
 
 ## Introduction
 This proposal adds automatic RPC generation for iOS and Java from the XML spec via a python script.
@@ -12,7 +12,7 @@ This proposal adds automatic RPC generation for iOS and Java from the XML spec v
 Adding RPCs is currently difficult. Every RPC to be added requires handwriting each parameter, then review, and then unit testing. This makes large RPC changes very difficult, and at times, error-prone. Beyond that, alterations to the RPC classes require an enormous amount of work due to the number of RPCs that already exist – in addition to the problems of code duplication. This does not happen often, but it does happen.
 
 ## Proposed solution
-The proposed solution is to create python scripts that auto-generate Objective-C and Android code based on a given SDL MOBILE_API XML spec. This allows us to generate new Obj-C and Android classes whenever the XML spec changes, and to update the script whenever the classes themselves need to change.
+The proposed solution is to create python scripts that auto-generate Objective-C, Android and JavaScript code based on a given SDL MOBILE_API XML spec. This allows us to generate new classes whenever the XML spec changes, and to update the script whenever the classes themselves need to change.
 
 The script should take a `MOBILE_API` XML spec as input and a location to output. The script will then output the RPC files at that location.
 
@@ -20,7 +20,10 @@ The script should take a `MOBILE_API` XML spec as input and a location to output
 1. The spec is not currently housed within the library. Therefore the `rpc_spec` repository will be pulled into each library repository as a submodule. The `MOBILE_API` in the `rpc_spec` submodule will be the version used by the script to output the RPC files.
 2. This proposal is left intentionally ambiguous regarding implementation details of the scripts. I wish to leave implementation details up to the author(s) of the scripts. However, the command-line switches should be identical between implementations.
 3. The different platform scripts should be very similar outside of the actual code that's generated (e.g. file system code and XML parsing code should be nearly identical).
-4. The author(s) of these scripts should use the `rpc_spec` markdown generator as a base.
+4. The author(s) of these scripts should use the `sdl_core` InterfaceBuilder as a base.
+5. The generator code that creates the library code should be located in the library repository. 
+6. The parser code that parses the `MOBILE_API` should be located in the `rpc_spec` repository. It will be included into the library repositories due to the submodule reference. This should help maintaining the parser code.
+
 
 ## Potential downsides
 1. Creating the generator scripts may take longer than simply handwriting, reviewing, and unit testing any particular RPC change. However, in the long run, the time savings will be significant.

--- a/proposals/0234-proxy-rpc-generation.md
+++ b/proposals/0234-proxy-rpc-generation.md
@@ -44,6 +44,8 @@ The script should take a `MOBILE_API` XML spec as input and a location to output
 
     The submodule reference was updated with more recent parser scripts but the generator scripts are not updated
 
+13. Python 2 support ends in 2020. Therfore, all python scripts should be developed for Python 3. This includes scripts from the InterfaceBuilder that will be refactored.
+
 ### Command-line switches
 
 The command-line switches of all generator scripts should be identical. Following list of command-line switches is proposed:

--- a/proposals/0234-proxy-rpc-generation.md
+++ b/proposals/0234-proxy-rpc-generation.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0234](0234-proxy-rpc-generation.md)
 * Author: [Joel Fischer](https://github.com/joeljfischer)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [iOS / Java Suite / JavaScript ]
+* Impacted Platforms: [ Core / iOS / Java Suite / JavaScript / RPC ]
 
 ## Introduction
 This proposal adds automatic RPC generation for iOS and Java from the XML spec via a python script.
@@ -12,17 +12,52 @@ This proposal adds automatic RPC generation for iOS and Java from the XML spec v
 Adding RPCs is currently difficult. Every RPC to be added requires handwriting each parameter, then review, and then unit testing. This makes large RPC changes very difficult, and at times, error-prone. Beyond that, alterations to the RPC classes require an enormous amount of work due to the number of RPCs that already exist – in addition to the problems of code duplication. This does not happen often, but it does happen.
 
 ## Proposed solution
-The proposed solution is to create python scripts that auto-generate Objective-C, Android and JavaScript code based on a given SDL MOBILE_API XML spec. This allows us to generate new classes whenever the XML spec changes, and to update the script whenever the classes themselves need to change.
+The proposed solution is to create python scripts that auto-generate Markdown, C++, Objective-C, Android/Java and JavaScript code based on a given SDL MOBILE_API XML spec. This allows us to generate new content whenever the XML spec changes, and to update the script whenever the classes themselves need to change.
 
 The script should take a `MOBILE_API` XML spec as input and a location to output. The script will then output the RPC files at that location.
 
 ### Implementation Notes
-1. The spec is not currently housed within the library. Therefore the `rpc_spec` repository will be pulled into each library repository as a submodule. The `MOBILE_API` in the `rpc_spec` submodule will be the version used by the script to output the RPC files.
-2. This proposal is left intentionally ambiguous regarding implementation details of the scripts. I wish to leave implementation details up to the author(s) of the scripts. However, the command-line switches should be identical between implementations.
+1. The spec is not currently housed within the library. Therefore the `rpc_spec` repository will be pulled into each library repository as a submodule. The `MOBILE_API` in the `rpc_spec` submodule will be the version used by the script to output the RPC files. Following repositories should include `rpc_spec`:
+
+    `sdl_core`, `sdl_java_suite`, `sdl_ios`, `sdl_javascript_suite`
+
+2. The command-line switches should be identical between implementations. See "Command-line switches" section for details.
 3. The different platform scripts should be very similar outside of the actual code that's generated (e.g. file system code and XML parsing code should be nearly identical).
-4. The author(s) of these scripts should use the `sdl_core` [InterfaceGenerator](https://github.com/smartdevicelink/sdl_core/blob/master/tools/InterfaceGenerator) as a base.
+4. The author(s) of these scripts should use the `sdl_core` [InterfaceGenerator](https://github.com/smartdevicelink/sdl_core/blob/master/tools/InterfaceGenerator) as a base. 
+
+    This base should be refactored with regards to code structure to improve the code quality and readability. Inline documentation should also be added to the scripts.
+
+    The generator scripts of the `InterfaceBuilder` that already creates code for Core should be refactored to use parser scripts from `rpc_spec` instead.
+    
 5. The generator code that creates the library code should be located in the library repository. 
 6. The parser code that parses the `MOBILE_API` should be located in the `rpc_spec` repository. It will be included into the library repositories due to the submodule reference. This should help maintaining the parser code.
+7. The `rpc_spec` repository should include generator scripts that can generate the README.md file for the GitHub repository.
+8. the `rpc_spec` repository should include an XSD file that defines the MOBILE_API XML file and relationship of the XML elements. _(Note: A PR already exist for the rpc_spec repository which includes a reverse engineered XSD file. see smartdevicelink/rpc_spec#202)_.
+9. The parser code that parses the MOBILE_API should use the XSD file to verify the integrity of the XML.
+10. The generator scripts are dependent on the parser scripts, therefore the generator scripts should import the parser scripts and call the parser functions.
+11. Both, the generator and parser scripts should be versioned with only a major version number. The version number should be stored as a number in a variable. Changes to the scripts should match with the major version, especially when the change impacts the interface of the parser scripts. Patch-like changes like a bugfix should not require a version bump.
+12. The generator script should compare the own version number with the version number of the parser script. If the version number does not match, the generator script should print an error message and stop the execution. This increases maintenance time but introduces a security check to make sure both sides are kept up-to-date. Following cases can cause a version mismatch:
+    
+    The generator script is updated to meet a new MOBILE API feature, but the submodule reference is not updated
+
+    The submodule reference was updated but the parser scripts are not up-to-date
+
+    The submodule reference was upated with more recent parser scripts but the generator scripts are not updated
+
+### Command-line switches
+
+The command-line switches of all generator scripts should be identical. Following list of command-line switches is proposed:
+
+- `<input-file>` - required, should point to `MOBILE_API.xml` and be provided to and used by the parser scripts.
+- `<output-directory>` - required, define the place where the generated output should be placed.
+- `[<regex-pattern>]` - optional, only elements matched with defined regex pattern will be parsed and generated, if present
+- `--help, -h` - print the help information and exit
+- `--version, -v` - print the version and exit
+- `--verbose` - display additional details like logs etc.
+- `--enums, -e, --structs, -s, --functions, -f` - only specified elements will be generated, if present
+- `--overwrite, -y` - force overwriting of existing files in the output directory, ignore confirmation message
+- `--skip, -n` - skip overwriting of existing files in the output directory, ignore confirmation message
+
 
 
 ## Potential downsides

--- a/proposals/0234-proxy-rpc-generation.md
+++ b/proposals/0234-proxy-rpc-generation.md
@@ -21,7 +21,7 @@ The script should take a `MOBILE_API` XML spec as input and a location to output
 
     `sdl_core`, `sdl_java_suite`, `sdl_ios`, `sdl_javascript_suite`
 
-2. The command-line switches should be identical between implementations. See "Command-line switches" section for details.
+2. This proposal is left intentionally ambiguous regarding implementation details of the scripts. I wish to leave implementation details up to the author(s) of the scripts. However, the command-line switches should be identical between implementations. See "Command-line switches" section for details.
 3. The different platform scripts should be very similar outside of the actual code that's generated (e.g. file system code and XML parsing code should be nearly identical).
 4. The author(s) of these scripts should use the `sdl_core` [InterfaceGenerator](https://github.com/smartdevicelink/sdl_core/blob/master/tools/InterfaceGenerator) as a base. 
 
@@ -32,7 +32,7 @@ The script should take a `MOBILE_API` XML spec as input and a location to output
 5. The generator code that creates the library code should be located in the library repository. 
 6. The parser code that parses the `MOBILE_API` should be located in the `rpc_spec` repository. It will be included into the library repositories due to the submodule reference. This should help maintaining the parser code.
 7. The `rpc_spec` repository should include generator scripts that can generate the README.md file for the GitHub repository.
-8. the `rpc_spec` repository should include an XSD file that defines the MOBILE_API XML file and relationship of the XML elements. _(Note: A PR already exist for the rpc_spec repository which includes a reverse engineered XSD file. see smartdevicelink/rpc_spec#202)_.
+8. the `rpc_spec` repository should include an XSD file that defines the MOBILE_API XML file and relationship of the XML elements. _(Note: A PR already exists for the rpc_spec repository which includes a reverse engineered XSD file. see https://github.com/smartdevicelink/rpc_spec/pull/202)_.
 9. The parser code that parses the MOBILE_API should use the XSD file to verify the integrity of the XML.
 10. The generator scripts are dependent on the parser scripts, therefore the generator scripts should import the parser scripts and call the parser functions.
 11. Both, the generator and parser scripts should be versioned with only a major version number. The version number should be stored as a number in a variable. Changes to the scripts should match with the major version, especially when the change impacts the interface of the parser scripts. Patch-like changes like a bugfix should not require a version bump.
@@ -42,7 +42,7 @@ The script should take a `MOBILE_API` XML spec as input and a location to output
 
     The submodule reference was updated but the parser scripts are not up-to-date
 
-    The submodule reference was upated with more recent parser scripts but the generator scripts are not updated
+    The submodule reference was updated with more recent parser scripts but the generator scripts are not updated
 
 ### Command-line switches
 

--- a/proposals/0234-proxy-rpc-generation.md
+++ b/proposals/0234-proxy-rpc-generation.md
@@ -20,7 +20,7 @@ The script should take a `MOBILE_API` XML spec as input and a location to output
 1. The spec is not currently housed within the library. Therefore the `rpc_spec` repository will be pulled into each library repository as a submodule. The `MOBILE_API` in the `rpc_spec` submodule will be the version used by the script to output the RPC files.
 2. This proposal is left intentionally ambiguous regarding implementation details of the scripts. I wish to leave implementation details up to the author(s) of the scripts. However, the command-line switches should be identical between implementations.
 3. The different platform scripts should be very similar outside of the actual code that's generated (e.g. file system code and XML parsing code should be nearly identical).
-4. The author(s) of these scripts should use the `sdl_core` InterfaceBuilder as a base.
+4. The author(s) of these scripts should use the `sdl_core` [InterfaceGenerator](https://github.com/smartdevicelink/sdl_core/blob/master/tools/InterfaceGenerator) as a base.
 5. The generator code that creates the library code should be located in the library repository. 
 6. The parser code that parses the `MOBILE_API` should be located in the `rpc_spec` repository. It will be included into the library repositories due to the submodule reference. This should help maintaining the parser code.
 


### PR DESCRIPTION
# Introduction

Update SDL-0234 Proxy Library RPC Generation to use `sdl_core` InterfaceGenerator code as the base and store parser related python code in `rpc_spec` repository instead of each library repository.

# Motivation

Luxoft, Ford and the PM agreed that using `sdl_core`'s InterfaceGenerator as a base is more helpful to implement this proposal. It contains a good amount of reusable python scripts to parse and generate code. It was also seen that the amount of code needed to parse the mobile API is much larger and complex than originally expected. Therefore we agreed that parsing code should be stored only in the `rpc_spec` repository. The library repositories should store the generating code only and "import" the parsing code including the mobile API by including the `rpc_spec` repository as a git submodule.

These agreements are related to items that are specifically mentioned/agreed in the proposal which is why the revision is proposed.

# Proposed Solution

The proposed revision includes following changes:

1. The spec is not currently housed within the library. Therefore the `rpc_spec` repository will be pulled into each library repository as a submodule. The `MOBILE_API` in the `rpc_spec` submodule will be the version used by the script to output the RPC files. Following repositories should include `rpc_spec`:

     `sdl_core`, `sdl_java_suite`, `sdl_ios`, `sdl_javascript_suite`

 2. This proposal is left intentionally ambiguous regarding implementation details of the scripts. I wish to leave implementation details up to the author(s) of the scripts. However, the command-line switches should be identical between implementations. See "Command-line switches" section for details.
 3. The different platform scripts should be very similar outside of the actual code that's generated (e.g. file system code and XML parsing code should be nearly identical).
 4. The author(s) of these scripts should use the `sdl_core` [InterfaceGenerator](https://github.com/smartdevicelink/sdl_core/blob/master/tools/InterfaceGenerator) as a base. 

     This base should be refactored with regards to code structure to improve the code quality and readability. Inline documentation should also be added to the scripts.

     The generator scripts of the `InterfaceBuilder` that already creates code for Core should be refactored to use parser scripts from `rpc_spec` instead.

 5. The generator code that creates the library code should be located in the library repository. 
 6. The parser code that parses the `MOBILE_API` should be located in the `rpc_spec` repository. It will be included into the library repositories due to the submodule reference. This should help maintaining the parser code.
 7. The `rpc_spec` repository should include generator scripts that can generate the README.md file for the GitHub repository.
 8. The `rpc_spec` repository should include an XSD file that defines the MOBILE_API XML file and relationship of the XML elements. _(Note: A PR already exists for the rpc_spec repository which includes a reverse engineered XSD file. see https://github.com/smartdevicelink/rpc_spec/pull/202)_.
 9. The parser code that parses the MOBILE_API should use the XSD file to verify the integrity of the XML.
 10. The generator scripts are dependent on the parser scripts, therefore the generator scripts should import the parser scripts and call the parser functions.
 11. Both, the generator and parser scripts should be versioned with only a major version number. The version number should be stored as a number in a variable. Changes to the scripts should match with the major version, especially when the change impacts the interface of the parser scripts. Patch-like changes like a bugfix should not require a version bump.
 12. The generator script should compare the own version number with the version number of the parser script. If the version number does not match, the generator script should print an error message and stop the execution. This increases maintenance time but introduces a security check to make sure both sides are kept up-to-date. Following cases can cause a version mismatch:

     The generator script is updated to meet a new MOBILE API feature, but the submodule reference is not updated

     The submodule reference was updated but the parser scripts are not up-to-date

     The submodule reference was updated with more recent parser scripts but the generator scripts are not updated

The InterfaceGenerator has much more reusable python scripts to parse the mobile API and to generate the desired code. Storing the parser scripts only once in the `rpc_spec` repository improves maintaining the parser code and reduces the risk of errors when storing copies of the parser scripts in each library repository.

# Potential Downsides

In order to assemble the generator scripts stored in a library repository and the parser scripts from the `rpc_spec` by including the repository as a git submodule requires some structuring of where the files are stored and where the submodule should be linked to. I don't believe it's a real downside. It just needs to be taken care of in each library repository.

Also, when changing the submodule reference to a new commit of `rpc_spec` it can be possible that the parser scripts and the generator scripts are not compatible anymore. Breaking changes could appear. However, the same issue is applicable to the current agreed status where the parsing scripts is not compatible with the mobile API file structure.

# Alternatives Considered

No other alternatives are considered for this proposed revision. It could be possible to only accept the change to use the InterfaceGenerator without changing the structure where the scripts should be located. Still, the author of this proposal revision recommends to accept all suggested points.
