### PR TITLE
Revise process.md and add sdl_releases.md

### DIFF
--- a/SDL_Releases.md
+++ b/SDL_Releases.md
@@ -1,0 +1,120 @@
+# SDL Releases Overview
+
+## Planning
+
+The SDLC Steering Committee meets toward the end of each year to plan the Roadmap for the following year.  Typically, the release schedule looks like this:
+
+- End of Q1: Mostly bug fixing with minimal RPC and Protocol Spec, all affected projects (see below)
+- End of Q2: Proxy (Java Suite and iOS) Libraries
+- End of Q3/Beginning of Q4 (largest release): RPC and Protocol Spec, all affected projects (see below)
+
+### Which projects need to be updated?<a id="which-projects-need-to-be-updated?"></a>
+
+Each project will have their own releases and features that only affect their specific platform. Most Core releases will include RPC or Protocol Spec changes; these modifications will affect the widest range of projects.
+
+Changes to RPC and Protocol Specs impact the following projects:
+
+- Core
+- Generic HMI
+- SDL HMI
+- ATF and scripts
+- Java Suite (Android, JavaSE, and JavaEE; including hello world samples)
+- iOS (including hello world sample)
+- RPC Spec (if RPC modification)
+- Protocol Spec (if Protocol Spec modification)
+- SDL Server
+- SHAID (SDLC Proprietary)
+- SDL Developer Portal (SDLC Proprietary)
+- Manticore
+- Documentation
+   - App Library Guides
+   - HMI Integration Guidelines
+   - Core Documentation
+   - Core Guides
+
+Changes to Core impact the following projects:
+
+- Core
+- Generic HMI (in most cases)
+- SDL HMI (in most cases)
+- ATF and scripts
+- Manticore
+- Documentation
+   - HMI Integration Guidelines
+   - Core Documentation
+   - Core Guides
+    
+Changes to the Java Suite project impact the following projects:
+
+- Java Suite (Android, JavaSE, and JavaEE; including hello world samples)
+- Documentation
+   - App Library Guides
+
+
+Changes to the iOS project impact the following projects:
+
+- iOS (including hello world sample)
+- Documentation
+   - App Library Guides
+
+For additional information see the [SDL Evolution README](https://github.com/smartdevicelink/sdl_evolution/blob/master/README.md).
+
+### Determining Priority and Timing
+
+The Project Maintainer will work with the SDLC Steering Committee to determine priority for the Core releases which include RPC and protocol modifications. After gathering priority from members, the Project Maintainer compiles the information and comes up with a rough estimate on what can be achieved. This will then involve working with SDLC members on their plans to contribute to the SDL project. These contributions will be considered donations. The Project Maintainer will use contribution dates from members and put together a plan for the release that can be followed.
+
+Members who have committed to contributing features will be responsible for meeting the contribution dates in order for that feature to be included in the planned release timeline.
+
+## Code Contributions
+
+### Who codes a feature/proposal?
+
+The general rule of thumb is that the author of an SDL Evolution proposal is the person or company who intends to contribute code for a feature. SDLC Member contributions should encompass all projects impacted by the feature (including documentation).  See the [Which projects need to be updated?](#which-projects-need-to-be-updated?) section for details.  Note that the following projects are exempt from this requirement for SDLC Members: SHAID, SDL Developer Portal, Manticore.
+
+
+### Project Maintainer Review
+
+The Project Maintainer will perform reviews on all contributions to ensure they are of the highest quality and stability before merging them into one of the mainline branches. 
+
+#### Prerequisites for SDLC Member Contributions
+
+- All contributions should be reviewed and tested before asking for the Project Maintainer to review.  This includes code review and testing with only and all affected open source components; testing with proprietary systems/apps/setups are not acceptable.
+    - If a supplier is contributing on behalf of an SDLC member, the SDLC member needs to approve the contribution before requesting Project Maintainer review.
+- All contributions should be in working order and should not require "special setup." 
+- All code should follow the contribution guidelines contained in the repository in which they are being donated.
+
+
+### Ready for Review
+
+Once the prerequesites for SDLC Member Contributions are met, and the pull request(s) has/have been submitted, the author or SDLC member contributing the code can tag `@theresalech` asking for the Project Maintainer to review.
+
+After the review request has been made, __no changes should be submitted to a pull request until the review round is over.__
+
+### Review Process
+
+While the contribution is being reviewed by the Project Maintainer, there are a few things to keep in mind:
+
+- Once the review process has started, do not push additional changes until the round of review is completed.
+- The Project Maintainer will perform a general code review as well as testing to ensure the pull request works as expected.
+- After the Project Maintainer has completed their review, the author should rework the pull request based on the reviewer's comments and concerns and again ensure that the feature/fix still works after the changes.
+- The author then pushes those changes into the remote branch and once again can tag the Project Maintainer reviewer to begin the next round of review.
+- This process continues until the pull request is approved by the Project Maintainer. 
+
+
+### When do contributions get reviewed?
+
+Contributions are reviewed based on SDLC priority and the annual SDL Roadmap. The Project Maintainer will work off the originally supplied contribution dates and assign time to review, which might mean there is time between the contribution date and the start of the Project Maintainer review.
+
+If a pull request has not been prioritized by the SDLC or is not part of the SDL Roadmap, there is no specific time table as to when it will be reviewed and merged. It is important to ask the SDLC to prioritize items that are important to you or your organization. 
+
+## Testing and Official Release
+
+Once all planned contributions have been implemented and merged into the respective mainline branch, the Project Maintainer performs end to end testing of the Release Candidate.  If necessary, the Project Maintainer provides the Steering Committee with a Release Candidate for review and approval.  
+
+As outlined in the Project Maintainer Agreement, the Steering Committee is responsible for approving the following releases:
+
+- Major Core Releases
+- Minor Core Releases
+- Major Proxy (iOS and Java Suite) Releases
+
+For releases requiring Steering Committee approval, there is typically a 1 month Release Candidate review period.  This includes time for the Steering Committee to review and perform testing, and the Project Maintainer to address any found issues.  This timing is subject to change at the Steering Committee's discretion.

--- a/SDL_Releases.md
+++ b/SDL_Releases.md
@@ -118,3 +118,14 @@ As outlined in the Project Maintainer Agreement, the Steering Committee is respo
 - Major Proxy (iOS and Java Suite) Releases
 
 For releases requiring Steering Committee approval, there is typically a 1 month Release Candidate review period.  This includes time for the Steering Committee to review and perform testing, and the Project Maintainer to address any found issues.  This timing is subject to change at the Steering Committee's discretion.
+
+## Hotfix Releases
+By SDLC Member or Project Maintainer request, hotfixes can be released as needed to resolve critical issues within a project.
+
+The process for requesting a hotfix release is as follows:
+
+1. Report the issue on the appropriate GitHub repository.
+2. If possible, submit a PR to resolve the issue on GitHub as well.
+3. Raise the issue (and PR, if applicable) during the `Issue Triage` portion of the Weekly Steering Committee meeting, or work with your Steering Committee representative to do so.
+
+The Steering Committee will then decide on the best course of action, including hotfix release timing, impact on previous releases and/or planned future releases.

--- a/SDL_Releases.md
+++ b/SDL_Releases.md
@@ -94,12 +94,12 @@ After the review request has been made, __no changes should be submitted to a pu
 
 While the contribution is being reviewed by the Project Maintainer, there are a few things to keep in mind:
 
-- Once the review process has started, do not push additional changes until the round of review is completed.
-- The Project Maintainer will perform a general code review as well as testing to ensure the pull request works as expected.
+- Once the review process has started, do not push additional changes until the round of review is completed.  The Project Maintainer will provide an estimate of review timing required if available.
+- The Project Maintainer will perform a general code review as well as testing to ensure the pull request works as expected, and inform the author when their review is complete and no new comments are expected in the currrent review iteration.
 - After the Project Maintainer has completed their review, the author should rework the pull request based on the reviewer's comments and concerns and again ensure that the feature/fix still works after the changes.
 - The author then pushes those changes into the remote branch and once again can tag the Project Maintainer reviewer to begin the next round of review.
-- This process continues until the pull request is approved by the Project Maintainer. 
-
+- This process continues until the pull request is approved by the Project Maintainer.
+- It is possible that during the Project Maintainer's review of a feature contribution, it's determined revisions to the original SDL Evolution Proposal for the feature are required.  Please see the [SDL Evolution Process document](https://github.com/smartdevicelink/sdl_evolution/blob/master/process.md) for more information on this process.  The Project Maintainer will work with the author and SDLC to determine any impact this revision may have on upcoming release timing.
 
 ### When do contributions get reviewed?
 

--- a/process.md
+++ b/process.md
@@ -1,17 +1,19 @@
 # SDL Evolution Process
-The SmartDeviceLink Consortium (SDLC) seeks the help of the community to help guide and shape how SDL changes. To do that effectively, we outline in this document a process for introducing ideas to SDL and how the SDLC Steering Committee will guide those ideas through the review process.
+The SmartDeviceLink Consortium (SDLC) seeks the help of the community to help guide and shape how SDL changes. To do that effectively, we outline in this document a process for introducing ideas to SDL and how the SDLC Steering Committee will guide those ideas through the review process.  
+
+The process outlined in this document should be strictly adhered to by all parties working on SDL, and any requests to diverge from the process outlined here will first require the Steering Committee to approve revisions to this document. 
 
 ## Scope
-Any changes to the [SDL RPC spec](https://github.com/smartdevicelink/rpc_spec), the [SDL protocol](https://github.com/smartdevicelink/protocol_spec), enhancements or major API changes to the SDL [iOS](https://github.com/smartdevicelink/sdl_ios) or [Java Suite](https://github.com/smartdevicelink/sdl_java_suite) SDKs, and [SDL Core](https://github.com/smartdevicelink/sdl_core) must go through the SDL evolution proposal and review process. An enhancement is defined as changing any behavior in a way that is different from the original definition of the behavior.  Please reference the [Proposals versus Issues document][proposals_versus_issues] for more information on what constitutes an Evolution Proposal versus a bug fix.  Major changes are defined according to [semantic versioning](http://www.semver.org).
+Any changes to the [SDL RPC spec](https://github.com/smartdevicelink/rpc_spec), the [SDL protocol](https://github.com/smartdevicelink/protocol_spec), enhancements or major API changes to the SDL [iOS](https://github.com/smartdevicelink/sdl_ios), [Java Suite](https://github.com/smartdevicelink/sdl_java_suite), or [JavaScript Suite](https://github.com/smartdevicelink/sdl_javascript_suite) SDKs, and [SDL Core](https://github.com/smartdevicelink/sdl_core) must go through the SDL evolution proposal and review process. An enhancement is defined as changing any behavior in a way that is different from the original definition of the behavior.  Please reference the [Proposals versus Issues document][proposals_versus_issues] for more information on what constitutes an Evolution Proposal versus a bug fix.  Major changes are defined according to [semantic versioning](http://www.semver.org).
 
 Bug fixes should go through the normal contribution process, for example, [this is the iOS repository's process](https://github.com/smartdevicelink/sdl_ios/blob/master/.github/CONTRIBUTING.md).
 
-If you have questions about if a particular case should be an Evolution Proposal or bug fix, please ask on [SDL slack][sdl_slack].
+If you have questions about if a particular case should be an Evolution Proposal or bug fix, please ask on [SDL Slack][sdl_slack].
 
 ## Participation
-Everyone is welcome to discuss and propose new changes to SDL on the [#sdl_evolution channel][sdl_evolution_channel] on the [SDL slack][sdl_slack]. Proposals under current review will be given an issue on the [sdl_evolution repository][sdl_evolution_repo]. Before posting a review, please read "What goes into a review?" below.
+Everyone is welcome to discuss and propose new changes to SDL on the [#sdl_evolution channel][sdl_evolution_channel] on the [SDL Slack][sdl_slack]. Proposals under current review will be given an issue on the [sdl_evolution repository][sdl_evolution_repo]. Before posting a review, please read "What goes into a review?" below.
 
-The SDLC is currently responsible for the strategic direction of SDL and will have the final say on the result of a proposal. A rationale will always be posted along with the result of the review of a proposal.
+The SDLC is currently responsible for the strategic direction of SDL and will have the final say on the result of a proposal. In order to best prepare to make a decision on each proposal, all SDLC members should review and provide feedback during the designated review period.  Once a decision has been made, a rationale will always be posted along with the result of the review of a proposal.
 
 ## What goes into a review?
 The goal of the review process is to improve the proposal under review through constructive criticism and, eventually, determine the direction of SDL. When writing your review, here are some questions you might want to answer in your review:
@@ -24,36 +26,37 @@ The goal of the review process is to improve the proposal under review through c
 
 Please state explicitly whether you believe that the proposal should be accepted into SDL.
 
-A review should be written as a comment on the Github issue of the proposal created by the review manager.
+A review should be written as a comment on the GitHub issue opened for the proposal.
 
 ## How to propose a change
 * **Check prior proposals**: many ideas come up frequently, and may either be in active discussion, or may have been discussed already and accepted or rejected.  Please check the [SDL Evolution Proposal Status page][sdl_evolution_proposal_status_page] for context before proposing something new.
 * **Socialize the idea**: if you're still working through the concept of your proposal, propose a rough sketch of the idea on the [#sdl_evolution channel][sdl_evolution_channel] of the [SDL Slack][sdl_slack], the problems it solves, what the solution looks like, etc., to gauge interest from the community.
-* **Develop the proposal**: expand the rough sketch into a complete proposal, using the [proposal template](0000-template.md), and continue to refine the proposal on the evolution slack channel. Prototyping an implementation and its uses along with the proposal is encouraged, because it helps ensure both technical feasibility of the proposal as well as validating that the proposal solves the problems it is meant to solve.
-* **Request a review**: initiate a pull request to the [sdl_evolution repository][sdl_evolution_repo] to indicate to the maintainers that you would like the proposal to be reviewed. When the proposal is sufficiently detailed and clear, and addresses feedback from earlier discussions of the idea, the pull request will be accepted. The proposal will be assigned a proposal number as well as a maintainer to manage the review. In addition, an issue will be opened specifically for the review and attached to the proposal.
-* **Address feedback**: in general, and especially during the review period, be responsive to questions and feedback about the proposal.
+* **Develop the proposal**: expand the rough sketch into a complete proposal, using the [proposal template](0000-template.md). The scope of the proposal should focus on a singluar feature. Prototyping an implementation and its uses along with the proposal is encouraged, because it helps ensure both technical feasibility of the proposal as well as validating that the proposal solves the problems it is meant to solve.
+* **Request a review**: initiate a pull request to the [sdl_evolution repository][sdl_evolution_repo] and follow the instructions in the [pull request template](https://github.com/smartdevicelink/sdl_evolution/blob/master/.github/PULL_REQUEST_TEMPLATE.md) to indicate that you would like the proposal to be reviewed. When the proposal is sufficiently detailed and clear, and addresses feedback from earlier discussions of the idea, a `review ready` label will be added to the pull request. Once the SDLC Steering Committee has voted to bring the proposal into review, it will be assigned a proposal number and an issue will be opened specifically for the review of the proposal.
+* **Address feedback**: in general, and especially during the review period, be responsive to questions and feedback about the proposal.  It is the proposal author's burden to advocate for their idea and be open to suggestions from the SDL community.
 
 ## Review process
-The review process for a particular proposal begins when the SDLC Steering Committee decides to accept a pull request of a new or updated proposal into the [sdl_evolution repository][sdl_evolution_repo]. The proposal is assigned a proposal number (if it is a new proposal), then enters the review queue.
+The review process for a particular proposal begins when the SDLC Steering Committee decides to accept a pull request of a new or updated proposal into the [sdl_evolution repository][sdl_evolution_repo]. The proposal is assigned a proposal number (if it is a new proposal), and a review issue is created on GitHub.
 
-The SDLC Steering Committee will work with the author to assess when the proposal is ready for review. Reviews usually last a single week, but can run longer for particularly large or complex proposals.
+The SDLC Steering Committee will review up to six (6) proposals each week.  This number can be reduced based on the complexity and/or context of the proposals. Reviews will last at least one week, but can run longer for particularly large or complex proposals.
 
-When the scheduled review period arrives, the review manager will post the proposal to the [#sdl_evolution slack channel][sdl_evolution_channel] and create a Github issue for the actual review, which will additionally be attached to the proposal. They will have the subject "[In Review]" followed by the proposal title. The Review Manager will be responsible for tracking the status of the proposal in the [proposal XML document][sdl_proposals_xml]. All feedback on the proposal should be addressed in the associated Github issue. To avoid delays, it is important that the proposal authors be available to answer questions, address feedback, and clarify their intent during the review period.
+When a review issue is created for a proposal, it is also shared on the [#sdl_evolution channel][sdl_evolution_channel] of the [SDL Slack][sdl_slack]. The issue will have the subject "[In Review]" followed by the proposal title. The status of proposals are tracked in the [proposals.xml document][sdl_proposals_xml]. All feedback on the proposal should be addressed in the associated GitHub issue. To avoid delays, it is important that the proposal author(s) be available to answer questions, address feedback, and clarify their intent during the review period.
 
-After the review has completed, the SDLC Steering Committee will make a decision on the proposal. The review manager is responsible for determining consensus among the SDLC Steering Committee, then reporting their decision to the proposal authors and SDL users. The review manager will update the proposal's state in the [sdl_evolution repository][sdl_evolution_repo] to reflect that decision, then close and lock the related issue. Possible decisions include: Accepted, Accepted with Revisions, Rejected, Returned for Revisions, Withdrawn, and Deferred.
+After the review has completed, the SDLC Steering Committee will make a decision on the proposal.  The decision will be reported on the GitHub issue for the proposal review. The proposal's state will be updated in the [sdl_evolution repository][sdl_evolution_repo] to reflect the decision, and the related issue will be closed and locked. Possible decisions include: Accepted, Accepted with Revisions, Rejected, Returned for Revisions, Withdrawn, and Deferred.
 
 ### Proposal Decision Types
-- **Accepted**: Proposal has been approved, and the SDL project maintainer will enter issues in respective repositories for implementation to commence.
-- **Accepted with Revisions**: Proposal has been approved, pending the (minor) revisions included in the SDLC Steering Committee's decision comment on the associated review issue.  The SDL project maintainer will enter issues in respective repositories for implementation once the proposal.md file has been revised to incorporate the requested revisions from the SDLC Steering Committee.
+- **Accepted**: Proposal has been approved, and issues will be entered in respective repositories for implementation to commence.
+- **Accepted with Revisions**: Proposal has been approved, pending the (minor) revisions included in the SDLC Steering Committee's decision comment on the associated review issue.  Issues will be entered in respective repositories for implementation once the proposal file has been revised to incorporate the requested revisions from the SDLC Steering Committee.
 - **Rejected**: Proposal was not approved due to the rationale provided in the SDLC Steering Committee's decision comment on the associated review issue.
 - **Withdrawn**: Author of proposal has requested that it no longer be considered for review.  This will only be applicable to proposals that have not yet been accepted or rejected.  After a proposal is withdrawn, any interested parties are able to become the author of the proposal to see it through further reviews and be voted upon by the SDLC Steering Committee.
-- **Returned for Revisions**: Proposal has been returned to the author to make significant revisions, as described in the SDLC Steering Committee's decision comment on the associated review issue.  The author will submit a pull request against the original proposal and notify the review manager once revisions are ready to be merged into the original proposal for another SDLC Steering Committee review.  After 2 weeks of inactivity on a proposal that has been returned for revisions, the proposal will be closed.  It will be reopened once the author has notified the review manager that revisions have been submitted for review.
-- **Deferred**: Proposal has been deemed not ready to be voted upon by the SDLC Steering Committee.  Proposals can be deferred if the SDLC plans to meet separately to discuss the proposal/feature in greater detail, or if the proposal is dependent on another proposal being submitted and/or accepted.  With the exception of deferring a proposal for plans to meet separately to discuss, after 2 weeks of inactivity on a proposal that has been deferred, the proposal will be closed.  When action is ready to be taken again on the deferred proposal, it will be reopened and brought back into review.
+- **Returned for Revisions**: Proposal has been returned to the author to make significant revisions, as described in the SDLC Steering Committee's decision comment on the associated review issue.  The author will submit a pull request against the original proposal and notify the Project Maintainer once revisions are ready to be merged into the original proposal for another SDLC Steering Committee review.  After 2 weeks of inactivity on a proposal that has been returned for revisions, the proposal issue will be closed.  It will be reopened once the author has notified the Project Maintainer that revisions have been submitted.
+- **Deferred**: Proposal has been deemed not ready to be voted upon by the SDLC Steering Committee.  Proposals can be deferred if the SDLC plans to meet separately to discuss the proposal/feature in greater detail, or if the proposal is dependent on another proposal being submitted and/or accepted.  With the exception of deferring a proposal for plans to meet separately to discuss, after 2 weeks of inactivity on a proposal that has been deferred, the proposal issue will be closed.  When action is ready to be taken again on the deferred proposal, the issue will be reopened and brought back into review.
 
-Proposals can also remain in review if the SDLC Steering Committee needs more time to review and discuss on the associated review issue.
+Proposals can also remain in review if the SDLC Steering Committee needs more time to review and discuss on the associated review issue.  Closing for after 2 weeks of inactivity applies to these proposals as well.
+
 
 ## Review announcement
-When a proposal enters review, an email using the following template will be sent to the [#sdl_evolution slack channel][sdl_evolution_channel] and to a Github issue:
+When a proposal enters review, a GitHub issue using the following template will be created in the sdl_evolution repository, and the issue will be shared on the [#sdl_evolution channel][sdl_evolution_channel] of the [SDL Slack][sdl_slack]:
 
 ---
 
@@ -85,9 +88,37 @@ More information about the SDL evolution process is available at:
 
 Thank you,
 
-\<\<REVIEW MANAGER NAME>>
-
 ---
+
+
+## Additional SDL Evolution Process Details
+
+### Revising Previously Accepted Proposals
+If it's determined that a previously accepted, but not yet implemented proposal requires revisions, a pull request will need to be entered to revise the original proposal. This can happen upon implementing a feature or reviewing the implementation for a feature.
+
+The pull request will be reviewed in the same way as a proposal.  Therefore, the pull request description should follow the format of the [proposal template](https://github.com/smartdevicelink/sdl_evolution/blob/master/0000-template.md).
+
+Please see an example of how to format this type of pull request [here](https://github.com/smartdevicelink/sdl_evolution/pull/775).
+
+### Making Significant Changes to a Proposal
+
+If you are requesting to change a proposal in review, and the solution in your proposal needs to be changed so significantly that it does not match the original solution, a new proposal should be submitted, and a request to reject or withdraw your original proposal should be brought to the Steering Committee.
+
+
+###Timing
+In general, actions taken on proposals should be limited to one per week.  Please see example situations below:
+
+- If the Steering Committee votes to return a proposal for revisions, bringing the revised proposal back into review cannot happen until the following week.  This allows for adequate time to ensure the Steering Committee's agreed upon revisions have been made.  
+- A proposal cannot be brought into review and voted upon in the same week, as Steering Committee representatives would not have sufficient time to review the proposal prior to voting.
+
+###For Consideration
+The SDL Community is a global community, and so it can be expected that comments will be made on review issues at various times.  For this reason, we do not have a "cutoff" time for leaving comments on review issues.  While this may sometimes result in a proposal needing to be kept in review an additional week to allow the author or commenter time to respond, we appreciate the understanding of the community to allow such global discussions to take place.
+
+##Implementation Responsibility
+
+The general rule of thumb is that the author of an SDL Evolution proposal is the person or company who intends to contribute code for a feature. SDLC Member contributions should encompass all projects impacted by the feature (including documentation).
+
+You can find more information about proposal implementations and release planning [here][sdl_releases].
 
 [sdl_evolution_repo]: https://github.com/smartdevicelink/sdl_evolution "SDL evolution repository"
 [sdl_slack]: http://slack.smartdevicelink.com "SDL slack"
@@ -97,3 +128,4 @@ Thank you,
 [sdl_proposals_xml]: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals.xml "SDL Proposals XML"
 [sdl_evolution_proposal_status_page]: https://smartdevicelink.github.io/sdl_evolution/ "SDL Evolution Proposal Status Page"
 [proposals_versus_issues]: https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals_versus_issues.md "Proposals versus Issues"
+[sdl_releases]: https://github.com/smartdevicelink/sdl_evolution/blob/master/sdl_releases.md "SDL Releases"


### PR DESCRIPTION
Documents should now reflect and better define the current process followed by the SDLC Steering Committee and open source SDL community.

The Steering Committee should review this PR and provide any feedback before documents are updated on `master`.