### PR TITLE
Add preferred FPS to VideoStreamingCapability

### DIFF
--- a/proposals/NNNN-add-preferred-FPS.md
+++ b/proposals/NNNN-add-preferred-FPS.md
@@ -1,0 +1,69 @@
+# Add preferred FPS to VideoStreamingCapability
+
+* Proposal: [SDL-NNNN](NNNN-add-preferred-FPS.md)
+* Author: [Shinichi Watanabe](https://github.com/shiniwat)
+* Status: **Awaiting review**
+* Impacted Platforms: [Core / iOS / Java Suite / RPC]
+
+## Introduction
+
+This proposal extends SDL video streaming feature by adding preferred FPS to VideoStreamingCapability, so that the quality of video projection can be adjusted per OEM.
+
+## Motivation
+
+Currently, SDL video streaming refers to VideoStreamingCapability, and mobile libraries respect for preferred resolution, maximum bitrate, video format, etc.
+However the frame rate of the video streaming totally depends on mobile applications, and some OEM's head unit may not work for high frame rate, such as 60 fps.
+This proposal allows head units to specify the preferred FPS, so that mobile library can refer to the specified value. 
+
+## Proposed solution
+
+The proposed solution is to add preferred FPS to VideoStreamingCapability. On a head unit, preferred FPS can be varied on screen resolution; i.e. frame rate can be higher for lower resolution, but the preferred FPS value can be used for the case where screen resolution is the preferred resolution value.
+Mobile Proxies should respect for the preferred FPS value, as well as they do for preferred resolution, maximum bitrate, etc.
+
+## Detailed design
+
+### RPC change (Mobile_API and HMI_API)
+
+Add preferredFPS to VideoStreamingCapability struct in both APIs.
+
+```xml
+    <struct name="VideoStreamingCapability" since="4.5">
+        <description>Contains information about this system's video streaming capabilities.</description>
+        ...
+        <!-- new param -->
+        <param name="preferredFPS" type="Integer" minvalue="0" maxvalue="2147483647" mandatory="false">
+            <description>Preferred frame rate of a video stream per second.</description>
+        </param>
+    </struct>
+```
+
+### iOS mobile proxy consideration
+
+A frame rate of iOS SDL application highly depends on how the application capture the video data.
+If the application uses AVCaptureDevice, the frame rate must fit into AVFrameRateRange in ACCaptureDevice.format.
+
+When encoding the video frame, the frame rate can be specified to kVTCompressionPropertyKey_ExpectedFrameRate in videoEncoderSettings, but [iOS documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_expectedframerate) says, “provided as a hint to the video encoder” and “The actual frame rate depends on frame durations and may vary.”
+
+So developers must make sure taking account of preferredFPS value for capturing the video frame, as well as configuring videoEncoderSettings.
+
+### Android mobile proxy consideration
+
+Android Java Suite library introduces the combination of VirtualDisplay and MediaEncoder to capture a SdlRemoteDisplay class and encode the video stream.
+When encoding the video frame, a Frame rate can be specified by MediaCodec#configure, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says, "For video encoders this value corresponds to the intended frame rate, although encoders are expected to support variable frame rate based on MediaCodec.BufferInfo#presentationTimeUs",
+so situation would be the same as iOS.
+
+The actual frame rate of MediaEncoder depends on the frequency of VirtualDisplay update, and varies on the application's (SdlRemoteDisplay's) content. 
+This issue will be addressed by another proposal later.
+
+## Potential Downsides
+
+Adding an optional parameter to VideoStreamingCapability has no downside. It will be specified by head unit, but how it is used is still up to mobile application.
+
+## Impact on existing code
+
+This proposal has no breaking change, so there should be no impact on existing code. As mentioned, it is still up to mobile application how the additional parameter (preferredFPS) is used.
+
+## Alternatives considered
+
+As well as other video streaming parameters, preferredFPS can be added to other RPC, like StartStream, SetVideoConfig, etc.
+But it makes more sense to handle preferred FPS parameter in the same way as bitrate, screen resolution, etc.

--- a/proposals/NNNN-add-preferred-FPS.md
+++ b/proposals/NNNN-add-preferred-FPS.md
@@ -49,10 +49,11 @@ So developers must make sure taking account of preferredFPS value for capturing 
 ### Android mobile proxy consideration
 
 Android Java Suite library introduces the combination of VirtualDisplay and MediaEncoder to capture a SdlRemoteDisplay class and encode the video stream.
-When encoding the video frame, a Frame rate can be specified by MediaCodec#configure, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says, "For video encoders this value corresponds to the intended frame rate, although encoders are expected to support variable frame rate based on MediaCodec.BufferInfo#presentationTimeUs",
+When encoding the video frame, a frame rate can be specified by MediaCodec#configure, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says, "For video encoders this value corresponds to the intended frame rate, although encoders are expected to support variable frame rate based on MediaCodec.BufferInfo#presentationTimeUs",
 so situation would be the same as iOS.
 
-The actual frame rate of MediaEncoder depends on the frequency of VirtualDisplay update, and varies on the application's (SdlRemoteDisplay's) content. 
+The actual frame rate of MediaEncoder depends on the frequency of input surface's update in VirtualDisplay, and varies on the application's (SdlRemoteDisplay's) content.
+
 This issue will be addressed by another proposal later.
 
 ## Potential Downsides

--- a/proposals/NNNN-add-preferred-FPS.md
+++ b/proposals/NNNN-add-preferred-FPS.md
@@ -7,24 +7,24 @@
 
 ## Introduction
 
-This proposal extends SDL video streaming feature by adding preferred FPS to VideoStreamingCapability, so that frame rate of video streaming can be adjusted per OEM.
+This proposal extends SDL video streaming feature by adding preferred FPS to `VideoStreamingCapability`, so that frame rate of video streaming can be adjusted per OEM.
 
 ## Motivation
 
-Currently, SDL video streaming refers to VideoStreamingCapability, and mobile libraries respect for preferred resolution, maximum bitrate, video format, etc.
+Currently, SDL video streaming refers to `VideoStreamingCapability` and mobile libraries respect for preferred resolution, maximum bitrate, video format, etc.
 However frame rate of video streaming totally depends on mobile applications, and some OEM's head unit may not work well for high frame rate, such as 60 fps.
 This proposal allows head units to specify the preferred FPS, so that mobile library can refer to the specified value. 
 
 ## Proposed solution
 
-The proposed solution is to add preferred FPS to VideoStreamingCapability. On a head unit, preferred FPS can be varied on screen resolution; i.e. frame rate can be higher for lower resolution, but the preferred FPS value can be used for the case where screen resolution is the preferred resolution value.
-Mobile Proxies should respect for the preferred FPS value, as well as they do for preferred resolution, maximum bitrate, etc.
+The proposed solution is to add preferred FPS to `VideoStreamingCapability`. On a head unit, preferred FPS can vary by screen resolution; i.e. frame rate can be higher for lower resolution, but the preferred FPS value can be used for the case where screen resolution is the preferred resolution value.
+Mobile proxies should respect the preferred FPS value, just as they do for preferred resolution, maximum bitrate, etc.
 
 ## Detailed design
 
 ### RPC change (Mobile_API and HMI_API)
 
-Add preferredFPS to VideoStreamingCapability struct in both APIs.
+Add `preferredFPS` to `VideoStreamingCapability` struct in both APIs.
 
 ```xml
     <struct name="VideoStreamingCapability" since="4.5">
@@ -37,11 +37,11 @@ Add preferredFPS to VideoStreamingCapability struct in both APIs.
     </struct>
 ```
 
-Like other parameters in VideoStreamingCapability, preferredFPS should be returned in GetSystemCapability RPC response.
+Like other parameters in `VideoStreamingCapability`, `preferredFPS` should be returned in `GetSystemCapability` RPC response.
 
 ### iOS mobile proxy changes
 
-Extend SDLVideoStreamingCapability class to have preferredFPS property:
+Extend `SDLVideoStreamingCapability` class to have `preferredFPS` property:
 
 SDLVideoStreamingCapability.h:
 
@@ -65,7 +65,7 @@ SDLVideoStreamingCapability.m:
 }
 ```
 
-And then, modify SDLStreamingVideoLifecycleManager#didEnterStateVideoStreamStarting, so that preferredFPS value would be taken into account:
+And then, modify `SDLStreamingVideoLifecycleManager#didEnterStateVideoStreamStarting`, so that `preferredFPS` value would be taken into account:
 ```objc
 static NSUInteger const defaultFrameRate = 15;
 
@@ -82,47 +82,47 @@ static NSUInteger const defaultFrameRate = 15;
 
 }
 ```
-Note that videoEncoderSettings property must be NSMutableDictionary as it now would be mutable.
+Note that `videoEncoderSettings` property must be `NSMutableDictionary` as it now would be mutable.
 
 ### iOS mobile proxy consideration
 
 A frame rate of iOS SDL application highly depends on how the application captures the video data.
 
-If an application uses combination of SDLCarWindow and SDLStreamingVideoLifecycleManager, above change should take account of
-1) videoEncoderSettings used in SDLStreamingVideoLifecycleManager,
-2) capture rate of CADisplayLink#preferredFramePerSecond (available in iOS10 or higher)
+If an application uses combination of `SDLCarWindow` and `SDLStreamingVideoLifecycleManager`, above change should take account of
+1) `videoEncoderSettings` used in `SDLStreamingVideoLifecycleManager`,
+2) capture rate of `CADisplayLink#preferredFramePerSecond` (available in iOS10 or higher)
 
 So that should suffice the needs.
 
-If an application uses AVCaptureDevice directly, and does not rely on SDLStreamingVideoLifecycleManager at all, the frame rate must fit into AVFrameRateRange in ACCaptureDevice.format.
+If an application uses `AVCaptureDevice` directly, and does not rely on `SDLStreamingVideoLifecycleManager` at all, the frame rate must fit into `AVFrameRateRange` in `AVCaptureDevice.format`.
 
-Regarding kVTCompressionPropertyKey_ExpectedFrameRate in videoEncoderSettings, however, [iOS documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_expectedframerate) says, “provided as a hint to the video encoder” and “The actual frame rate depends on frame durations and may vary.”
-Therefore, developers must make sure taking account of preferredFPS value for capturing video frames (especially if the app does not use SDLCarWindow), as well as configuring videoEncoderSettings.
+Regarding `kVTCompressionPropertyKey_ExpectedFrameRate` in `videoEncoderSettings`, however, [iOS documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_expectedframerate) says, “provided as a hint to the video encoder” and “The actual frame rate depends on frame durations and may vary.”
+Therefore, developers must make sure taking account of `preferredFPS` value for capturing video frames (especially if the app does not use `SDLCarWindow`), as well as configuring `videoEncoderSettings`.
 
 ### Android mobile proxy consideration
 
-Android Java Suite library introduces the combination of VirtualDisplay and MediaEncoder to capture a SdlRemoteDisplay class and encode the video stream.
-When encoding the video frame, a frame rate can be specified by MediaCodec#configure, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says,
+Android Java Suite library introduces the combination of `VirtualDisplay` and `MediaEncoder` to capture a `SdlRemoteDisplay` class and encode the video stream.
+When encoding the video frame, a frame rate can be specified by `MediaCodec#configure`, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says,
 
 "For video encoders this value corresponds to the intended frame rate, although encoders are expected to support variable frame rate based on MediaCodec.BufferInfo#presentationTimeUs".
 
 Therefore situation would be the same as iOS; i.e. mobile developer must take care of actual frame rate.
 
-The actual frame rate of MediaEncoder depends on the frequency of input surface's update in VirtualDisplay, and varies on the application's (SdlRemoteDisplay's) content.
+The actual frame rate of `MediaEncoder` depends on the frequency of input surface's update in `VirtualDisplay`, and varies on the application's (`SdlRemoteDisplay`'s) content.
 
-For instance, if the VirtualDisplay gets updated aggressively, the frame rate would be larger than 60 fps, while in idle time, the frame rate will be something like 20 fps.
+For instance, if the `VirtualDisplay` gets updated aggressively, the frame rate would be larger than 60 fps, while in idle time, the frame rate will be something like 20 fps.
 
 This issue will be addressed by another proposal later.
 
 ## Potential Downsides
 
-Adding an optional parameter to VideoStreamingCapability has no downside. It will be specified by head unit, but how it is used is still up to mobile application.
+Adding an optional parameter to `VideoStreamingCapability` has no downside. It will be specified by head unit, but how it is used is still up to the mobile application.
 
 ## Impact on existing code
 
-This proposal has no breaking change, so there should be no impact on existing code. As mentioned, it is still up to mobile application how the additional parameter (preferredFPS) is used.
+This proposal has no breaking change, so there should be no impact on existing code. As mentioned, it is still up to the mobile application to determine how the additional parameter (`preferredFPS`) is used.
 
 ## Alternatives considered
 
-As well as other video streaming parameters, preferredFPS can be added to other RPC, like StartStream, SetVideoConfig, etc.
-But it makes more sense to handle preferredFPS parameter in the same way as bitrate, screen resolution, etc.
+As well as other video streaming parameters, `preferredFPS` can be added to other RPCs, like `StartStream`, `SetVideoConfig`, etc.
+But it makes more sense to handle `preferredFPS` parameter in the same way as bitrate, screen resolution, etc.

--- a/proposals/NNNN-add-preferred-FPS.md
+++ b/proposals/NNNN-add-preferred-FPS.md
@@ -32,7 +32,7 @@ Add preferredFPS to VideoStreamingCapability struct in both APIs.
         ...
         <!-- new param -->
         <param name="preferredFPS" type="Integer" minvalue="0" maxvalue="2147483647" mandatory="false">
-            <description>Preferred frame rate of a video stream per second.</description>
+            <description>Preferred frame rate of a video stream per second. Mobile application should take this value into account for capturing and encoding video frame.</description>
         </param>
     </struct>
 ```
@@ -40,11 +40,16 @@ Add preferredFPS to VideoStreamingCapability struct in both APIs.
 ### iOS mobile proxy consideration
 
 A frame rate of iOS SDL application highly depends on how the application capture the video data.
-If the application uses AVCaptureDevice, the frame rate must fit into AVFrameRateRange in ACCaptureDevice.format.
 
-When encoding the video frame, the frame rate can be specified to kVTCompressionPropertyKey_ExpectedFrameRate in videoEncoderSettings, but [iOS documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_expectedframerate) says, “provided as a hint to the video encoder” and “The actual frame rate depends on frame durations and may vary.”
+If an application uses SDLCarWindow, SDLCarWindow internally has videoEncoderSettings property, which is used both in encoder settings (kVTCompressionPropertyKey_ExpectedFrameRate in VideoEncoderSetting) and capture rate (CADisplayLink#preferredFramePerSecond available in iOS10 or higher).
+So SDLCarWindow should take account of preferredFPS value and use the value for videoEncoderSettings property.
 
-So developers must make sure taking account of preferredFPS value for capturing the video frame, as well as configuring videoEncoderSettings.
+If an application uses AVCaptureDevice directly, the frame rate must fit into AVFrameRateRange in ACCaptureDevice.format.
+
+Regarding kVTCompressionPropertyKey_ExpectedFrameRate in videoEncoderSettings, however, [iOS documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_expectedframerate) says, “provided as a hint to the video encoder” and “The actual frame rate depends on frame durations and may vary.”
+
+Overall, developers must make sure taking account of preferredFPS value for capturing the video frame (especially if the app does not use SDLCarWindow), as well as configuring videoEncoderSettings.
+
 
 ### Android mobile proxy consideration
 

--- a/proposals/NNNN-add-preferred-FPS.md
+++ b/proposals/NNNN-add-preferred-FPS.md
@@ -37,6 +37,8 @@ Add preferredFPS to VideoStreamingCapability struct in both APIs.
     </struct>
 ```
 
+Like other parameters in VideoStreamingCapability, preferredFPS should be returned in GetSystemCapability RPC response.
+
 ### iOS mobile proxy consideration
 
 A frame rate of iOS SDL application highly depends on how the application capture the video data.
@@ -48,7 +50,7 @@ If an application uses AVCaptureDevice directly, the frame rate must fit into AV
 
 Regarding kVTCompressionPropertyKey_ExpectedFrameRate in videoEncoderSettings, however, [iOS documentation](https://developer.apple.com/documentation/videotoolbox/kvtcompressionpropertykey_expectedframerate) says, “provided as a hint to the video encoder” and “The actual frame rate depends on frame durations and may vary.”
 
-Overall, developers must make sure taking account of preferredFPS value for capturing the video frame (especially if the app does not use SDLCarWindow), as well as configuring videoEncoderSettings.
+Overall, developers must make sure taking account of preferredFPS value for capturing video frames (especially if the app does not use SDLCarWindow), as well as configuring videoEncoderSettings.
 
 
 ### Android mobile proxy consideration

--- a/proposals/NNNN-add-preferred-FPS.md
+++ b/proposals/NNNN-add-preferred-FPS.md
@@ -7,12 +7,12 @@
 
 ## Introduction
 
-This proposal extends SDL video streaming feature by adding preferred FPS to VideoStreamingCapability, so that the quality of video projection can be adjusted per OEM.
+This proposal extends SDL video streaming feature by adding preferred FPS to VideoStreamingCapability, so that frame rate of video streaming can be adjusted per OEM.
 
 ## Motivation
 
 Currently, SDL video streaming refers to VideoStreamingCapability, and mobile libraries respect for preferred resolution, maximum bitrate, video format, etc.
-However the frame rate of the video streaming totally depends on mobile applications, and some OEM's head unit may not work for high frame rate, such as 60 fps.
+However frame rate of video streaming totally depends on mobile applications, and some OEM's head unit may not work well for high frame rate, such as 60 fps.
 This proposal allows head units to specify the preferred FPS, so that mobile library can refer to the specified value. 
 
 ## Proposed solution
@@ -32,7 +32,7 @@ Add preferredFPS to VideoStreamingCapability struct in both APIs.
         ...
         <!-- new param -->
         <param name="preferredFPS" type="Integer" minvalue="0" maxvalue="2147483647" mandatory="false">
-            <description>Preferred frame rate of a video stream per second. Mobile application should take this value into account for capturing and encoding video frame.</description>
+            <description>Preferred frame rate per second. Mobile application should take this value into account for capturing and encoding video frame.</description>
         </param>
     </struct>
 ```
@@ -86,7 +86,7 @@ Note that videoEncoderSettings property must be NSMutableDictionary as it now wo
 
 ### iOS mobile proxy consideration
 
-A frame rate of iOS SDL application highly depends on how the application capture the video data.
+A frame rate of iOS SDL application highly depends on how the application captures the video data.
 
 If an application uses combination of SDLCarWindow and SDLStreamingVideoLifecycleManager, above change should take account of
 1) videoEncoderSettings used in SDLStreamingVideoLifecycleManager,
@@ -102,8 +102,11 @@ Therefore, developers must make sure taking account of preferredFPS value for ca
 ### Android mobile proxy consideration
 
 Android Java Suite library introduces the combination of VirtualDisplay and MediaEncoder to capture a SdlRemoteDisplay class and encode the video stream.
-When encoding the video frame, a frame rate can be specified by MediaCodec#configure, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says, "For video encoders this value corresponds to the intended frame rate, although encoders are expected to support variable frame rate based on MediaCodec.BufferInfo#presentationTimeUs",
-so situation would be the same as iOS.
+When encoding the video frame, a frame rate can be specified by MediaCodec#configure, but [Android documentation](https://developer.android.com/reference/android/media/MediaFormat.html#KEY_FRAME_RATE) says,
+
+"For video encoders this value corresponds to the intended frame rate, although encoders are expected to support variable frame rate based on MediaCodec.BufferInfo#presentationTimeUs".
+
+Therefore situation would be the same as iOS; i.e. mobile developer must take care of actual frame rate.
 
 The actual frame rate of MediaEncoder depends on the frequency of input surface's update in VirtualDisplay, and varies on the application's (SdlRemoteDisplay's) content.
 
@@ -122,4 +125,4 @@ This proposal has no breaking change, so there should be no impact on existing c
 ## Alternatives considered
 
 As well as other video streaming parameters, preferredFPS can be added to other RPC, like StartStream, SetVideoConfig, etc.
-But it makes more sense to handle preferred FPS parameter in the same way as bitrate, screen resolution, etc.
+But it makes more sense to handle preferredFPS parameter in the same way as bitrate, screen resolution, etc.


### PR DESCRIPTION
This proposal extends SDL video streaming feature by adding preferred FPS to VideoStreamingCapability, so that frame rate of video streaming can be adjusted per OEM.