### PR TITLE
Revise SDL-0240 WebEngine Support

### DIFF
--- a/proposals/0240-sdl-js-pwa.md
+++ b/proposals/0240-sdl-js-pwa.md
@@ -326,7 +326,7 @@ Many services are available over a web application and modern WebEngines provide
   <description>
     HMI >SDL. RPC used to get the current properties of an application
   </description>
-  <param name="appID" type="String" maxlength="100" mandatory="false">
+  <param name="policyAppID" type="String" maxlength="100" minlength="1" mandatory="false">
     If specified the response will contain the properties of the specified app ID.
     Otherwise if omitted all app properties will be returned at once.
   </param>


### PR DESCRIPTION
## Introduction
Update [SDL-0240](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0240-sdl-js-pwa.md) in order to guarantee correct parameters handling in RPC processing,
parameters containing the same value, which are used for one purpose should
have the same name, type and restrictions within the same RPC.

## Motivation
Perform correct parameters handling

## Proposed solution
The proposed change is aligning parameter name and its length in GetAppProperties request and GetAppProperties response RPC. 

## Potential downsides
None

## Impact on existing code
None

## Alternatives considered
None