### PR TITLE
SDL 0259 - Disabled Softbuttons

### DIFF
--- a/proposals/0259-DisabledSoftbuttons.md
+++ b/proposals/0259-DisabledSoftbuttons.md
@@ -1,5 +1,6 @@
 
 
+
 # Disabled Softbuttons
 
 * Proposal: [SDL-0259](0259-DisabledSoftbuttons.md)
@@ -35,7 +36,7 @@ So we would add this to the MOBILE_API and HMI_API:
 </struct>
 ```
 
-Plus add an `isDisabled` flag to `SoftButton`. If the flag is false or missing, the softbutton must appear usable. If true, the `SoftButton` will still show on the HMI but appear grayed out or otherwise disabled. Button press events will still be sent to the app so the app can enable experiences like "Repeat is for Premium customers only". If a button is set to disabled and highlighted, it's up to the HMI to depict the best possible UI.
+Plus add an `isDisabled` flag to `SoftButton`. If the flag is false or missing, the softbutton must appear usable. If true, the `SoftButton` will still show on the HMI but appear grayed out or otherwise disabled. Button press events will still be sent to the app so the app can enable experiences like "Repeat is for Premium customers only". If a button would be disabled by the HMI for any reason (e.g. for DD), and the button is requested as disabled by the app, the HMI's disable would be higher priority.  If a button is set to disabled and highlighted, it's up to the HMI to depict the best possible UI.
 ```xml
 <struct name="SoftButton">
 .
@@ -54,7 +55,7 @@ For buttons that can be subscribed to, add a parameter to `ButtonCapabilities` t
     .
     .
     .
-    <param name="disabledButtonPossible" type="Boolean" mandatory="true">
+    <param name="disabledSupported" type="Boolean" mandatory="false">
         <description>The button supports being disabled. If the button is set to disabled, it will still show on the HMI but appear grayed out.
         </description>
     </param>
@@ -129,8 +130,8 @@ public class SoftButtonConfiguration {
 3. The `disabled` property will have to be added to `SoftButtonState`:
 
 ```Java
-	public boolean getDisabled(){};
-	public void setDisabled(boolean disabled){};
+	public boolean isDisabled() { ... }
+	public void setDisabled(bool disabled) { ... }
 ```
 
 The soft button manager will then have to take both the configuration value and the `disabled` BOOL on the state into account to determine if the button will be sent or not and with what values. If the app is connected to an older head unit that doesn't support disabled `SoftButton`s, the manager would make sure that the button is not sent to the head unit if the `SoftButtonConfiguration.disabledButtonFallback = true`.

--- a/proposals/0259-DisabledSoftbuttons.md
+++ b/proposals/0259-DisabledSoftbuttons.md
@@ -36,13 +36,13 @@ So we would add this to the MOBILE_API and HMI_API:
 </struct>
 ```
 
-Plus add an `isDisabled` flag to `SoftButton`. If the flag is false or missing, the softbutton must appear usable. If true, the `SoftButton` will still show on the HMI but appear grayed out or otherwise disabled. Button press events will still be sent to the app so the app can enable experiences like "Repeat is for Premium customers only". If a button would be disabled by the HMI for any reason (e.g. for DD), and the button is requested as disabled by the app, the HMI's disable would be higher priority.  If a button is set to disabled and highlighted, it's up to the HMI to depict the best possible UI.
+Plus add an `disabled` flag to `SoftButton`. If the flag is false or missing, the softbutton must appear usable. If true, the `SoftButton` will still show on the HMI but appear grayed out or otherwise disabled. Button press events will still be sent to the app so the app can enable experiences like "Repeat is for Premium customers only". If a button would be disabled by the HMI for any reason (e.g. for DD), and the button is requested as disabled by the app, the HMI's disable would be higher priority.  If a button is set to disabled and highlighted, it's up to the HMI to depict the best possible UI.
 ```xml
 <struct name="SoftButton">
 .
 .
 .
-    <param name="isDisabled" type="Boolean" mandatory="false" since="X.X">
+    <param name="disabled" type="Boolean" mandatory="false" since="X.X">
       <description>If false or missing, softbutton must appear usable. If true, softbutton must appear as not usable. Button press events will still be sent to the app regardless.
       </description>
     </param>
@@ -63,7 +63,7 @@ For buttons that can be subscribed to, add a parameter to `ButtonCapabilities` t
 
 ```
 
-Plus add an `isDisabled` flag to the `SubscribeButton` RPC.  If the button is set to disabled, it will still show on the HMI but appear grayed out. Button press events would still be sent to the app so the app can enable experiences like "Seek Left is for Premium customers only". 
+Plus add an `disabled` flag to the `SubscribeButton` RPC.  If the button is set to disabled, it will still show on the HMI but appear grayed out. Button press events would still be sent to the app so the app can enable experiences like "Seek Left is for Premium customers only". 
 
 ```xml
     <function name="SubscribeButton" functionID="SubscribeButtonID" messagetype="request" since="1.0">
@@ -75,7 +75,7 @@ Plus add an `isDisabled` flag to the `SubscribeButton` RPC.  If the button is se
         .
         .
         .
-            <param name="isDisabled" type="Boolean" mandatory="false" since="X.X">
+            <param name="disabled" type="Boolean" mandatory="false" since="X.X">
       <description>If false or missing, subscribed button must appear on screen and usable. If true, softbutton must appear on screen (if applicable) and not usable.  Button press events will still be sent to the app regardless.
       </description>
     </function>


### PR DESCRIPTION
This feature would allow apps to send custom softbuttons to display on screen but they would appear disabled. This also allows an app to subscribe to and disable SDL predefined buttons.

These are the final changes for the "Accepted with revisions" from the SDLC