### PR TITLE
SDL 0167 revisions - Voice Assistant

### DIFF
--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -500,7 +500,7 @@ Disadvantage: The user may feel inconvenient because there are two actions to be
 Advantage: The user can launch without button operation
 Disadvantage: The user needs to speak two kinds of wake words; NativeVR and SDL
 
-4. When NativeVR exists and always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to NativeVR wake words.
+4. When NativeVR exists and is always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to the NativeVR wake word.
 Advantage: The user can launch by just speaking one kind of wake words
 Disadvantage: HMI needs to support SDL wake words with NativeVR
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -501,7 +501,7 @@ Advantage: The user can launch without button operation
 Disadvantage: The user needs to say two wake words: NativeVR and SDL
 
 4. When NativeVR exists and is always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to the NativeVR wake word.
-Advantage: The user can launch by just saying one of wake word
+Advantage: The user can launch by just saying one wake word
 Disadvantage: HMI needs to support SDL wake word with NativeVR
 
 ### Flows

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -486,7 +486,7 @@ Apple CarPlay and Google Android Auto are examples where NativeVR and voice assi
 
 In addition, there are also home devices equipped with voice assistant such as Amazon Echo and Google Nest. But, it is unlikely that other voice assistants will get mixed up because those devices use their own exclusive voice assistants.
 
-Based from the mentioned above, we have considered that both the identification by long press/short press and the identification by wake word are realistic. In here, we describe the recommended cases for each in-vehicle device system using PTT and wake word.
+Based on the above, we have considered that both the identification by long press/short press and the identification by wake word are realistic. In this proposal, we describe the recommended cases for each in-vehicle device system using PTT and wake word.
 
 1. When NativeVR exists but has no registration of wake word or NativeVR does NOT exists, the user uses PTT button with long press/short press.
 Advantage: HMI implementation and process are simple

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -479,7 +479,7 @@ The application that has received `OnVoiceAssistantActivated` must refer to the 
 
 ##### Ways to launch Voice Assistant
 
-Apple CarPlay and Google Android Auto are examples where NativeVR and voice assistant are mixed up. However, there are ways on how to differentiate the use (of NativeVR and voice assistant in Apple CarPlay or Google Android Auto).
+Apple CarPlay and Google Android Auto are examples where NativeVR and voice assistant are mixed up. However, there are ways to differentiate the use (of NativeVR and voice assistant in Apple CarPlay or Google Android Auto).
 
 - When Apple CarPlay or Google Android Auto is connected, pressing the talk button launches Apple CarPlay or Google Android Auto voice assistant while others launch NativeVR.
 - A short press of talk button launches NativeVR; a long press launches Apple CarPlay or Google Android Auto voice assistant.

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -48,7 +48,7 @@ _Same for both MOBILE\_API and HMI\_API._
 +	 <element name = "VOICE_ASSISTANT"/>
 </enum>
 ```
-Note: A new service type, `VOICE_ASSISTANT` is added. See [Voice Assistant](#Voice Assistant) section.
+Note: A new service type, `VOICE_ASSISTANT`, is added. See [Voice Assistant](#Voice Assistant) section.
 
 Each service type will have two structs specifically defined for them.
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -502,7 +502,7 @@ Disadvantage: The user needs to say two wake words; NativeVR and SDL
 
 4. When NativeVR exists and is always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to the NativeVR wake word.
 Advantage: The user can launch by just saying one of wake word
-Disadvantage: HMI needs to support SDL wake words with NativeVR
+Disadvantage: HMI needs to support SDL wake word with NativeVR
 
 ### Flows
 -------

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -492,7 +492,7 @@ Based on the above, we have considered that both the identification by long pres
 Advantage: HMI implementation and process are simple
 Disadvantage: It requires an active service configuration by the user
 
-2. When NativeVR exists but not always detecting/listening, the user speaks SDL wake word after pressing the PTT button.
+2. When NativeVR exists but is not always detecting/listening, the user speaks SDL wake word after pressing the PTT button.
 Advantage: Users can precisely select the service they want to use
 Disadvantage: The user may feel inconvenient because there are two actions to be performed
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -488,7 +488,7 @@ In addition, there are also home devices equipped with voice assistant such as A
 
 Based on the above, we have considered that both the identification by long press/short press and the identification by wake word are realistic. In this proposal, we describe the recommended cases for each in-vehicle device system using PTT and wake word.
 
-1. When NativeVR exists but has no registration of wake word or NativeVR does NOT exists, the user uses PTT button with long press/short press.
+1. When NativeVR exists but has no registration of wake word or NativeVR does NOT exist, the user uses PTT button with long press/short press.
 Advantage: HMI implementation and process are simple
 Disadvantage: It requires an active service configuration by the user
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -496,7 +496,7 @@ Disadvantage: It requires an active service configuration by the user
 Advantage: Users can precisely select the service they want to use
 Disadvantage: The user may feel inconvenient because there are two actions to be performed
 
-3. When NativeVR exists and always detecting/listening (NativeVR wake word only), the user speaks SDL wake word after speaking NativeVR wake word.
+3. When NativeVR exists and is always detecting/listening (NativeVR wake word only), the user speaks SDL wake word after speaking NativeVR wake word.
 Advantage: The user can launch without button operation
 Disadvantage: The user needs to speak two kinds of wake words; NativeVR and SDL
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -484,7 +484,7 @@ Apple CarPlay and Google Android Auto are examples where NativeVR and voice assi
 - When Apple CarPlay or Google Android Auto is connected, pressing the talk button launches Apple CarPlay or Google Android Auto voice assistant while others launch NativeVR.
 - A short press of talk button launches NativeVR; a long press launches Apple CarPlay or Google Android Auto voice assistant.
 
-In addition, there are also home devices equipped with voice assistant such as Amazon Echo and Google Nest. But, it is unlikely that other voice assistants will get mixed up because those devices use (their own) exclusive voice assistants.
+In addition, there are also home devices equipped with voice assistant such as Amazon Echo and Google Nest. But, it is unlikely that other voice assistants will get mixed up because those devices use their own exclusive voice assistants.
 
 Based from the mentioned above, we have considered that both the identification by long press/short press and the identification by wake word are realistic. In here, we describe the recommended cases for each in-vehicle device system using PTT and wake word.
 

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -501,7 +501,7 @@ Advantage: The user can launch without button operation
 Disadvantage: The user needs to say two wake words; NativeVR and SDL
 
 4. When NativeVR exists and is always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to the NativeVR wake word.
-Advantage: The user can launch by just speaking one kind of wake words
+Advantage: The user can launch by just saying one of wake word
 Disadvantage: HMI needs to support SDL wake words with NativeVR
 
 ### Flows

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -498,7 +498,7 @@ Disadvantage: The user may feel inconvenienced because there are two actions to 
 
 3. When NativeVR exists and is always detecting/listening (NativeVR wake word only), the user speaks SDL wake word after speaking NativeVR wake word.
 Advantage: The user can launch without button operation
-Disadvantage: The user needs to say two wake words; NativeVR and SDL
+Disadvantage: The user needs to say two wake words: NativeVR and SDL
 
 4. When NativeVR exists and is always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to the NativeVR wake word.
 Advantage: The user can launch by just saying one of wake word

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -498,7 +498,7 @@ Disadvantage: The user may feel inconvenient because there are two actions to be
 
 3. When NativeVR exists and is always detecting/listening (NativeVR wake word only), the user speaks SDL wake word after speaking NativeVR wake word.
 Advantage: The user can launch without button operation
-Disadvantage: The user needs to speak two kinds of wake words; NativeVR and SDL
+Disadvantage: The user needs to say two wake words; NativeVR and SDL
 
 4. When NativeVR exists and is always detecting/listening (both NativeVR and SDL wake words are available), the user speaks SDL wake word that is equivalent to the NativeVR wake word.
 Advantage: The user can launch by just speaking one kind of wake words

--- a/proposals/0167-app-services.md
+++ b/proposals/0167-app-services.md
@@ -494,7 +494,7 @@ Disadvantage: It requires an active service configuration by the user
 
 2. When NativeVR exists but is not always detecting/listening, the user speaks SDL wake word after pressing the PTT button.
 Advantage: Users can precisely select the service they want to use
-Disadvantage: The user may feel inconvenient because there are two actions to be performed
+Disadvantage: The user may feel inconvenienced because there are two actions to be performed
 
 3. When NativeVR exists and is always detecting/listening (NativeVR wake word only), the user speaks SDL wake word after speaking NativeVR wake word.
 Advantage: The user can launch without button operation


### PR DESCRIPTION
## Introduction

A revision of SDL-0167 App Services and introduction of a new type of app service, `VOICE_ASSISTANT`. In here, the very basic part  of the voice assistant service is proposed.

## Motivation

The app service, `VOICE_ASSISTANT` was originally proposed, but as a result of trying to include many functions, it could not be converged and was deferred.
In this revision, the very basic part of the voice assistant service is implemented as the first step in developing. In addition, an environment that can use the voice assistant service with app service is also prepared.
With app service function, it allows the voice assistant service to avoid conflict with the NativeVR and the user to select an active service.

## Proposed solution

- A new service type, `VOICE_ASSISTANT`, is added.
- New RPC for Voice Assistant
  - OnVoiceAssistantActivated
- Add VoiceAssistantOperationCapabilities

## Potential downsides

No downsides are expected by this proposal. 

## Impact on existing code

Core, iOS, Java Suite, RPC needs to be updated.

## Alternatives considered

None