### PR TITLE
SDL 0273 WebEngine Projection Mode - Revisions

### DIFF
--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0273](0273-webengine-projection-mode.md)
 * Author: [Kujtim Shala](https://github.com/kshala-ford)
 * Status: **Returned for Revisions**
-* Impacted Platforms: [Core / JavaScript ]
+* Impacted Platforms: [ Core / JavaScript / RPC ]
 
 ## Introduction
 
@@ -16,19 +16,61 @@ This proposal describes a feature made possible using a WebEngine. A WebEngine c
 
 ## Proposed solution
 
-The app HMI type `PROJECTION` should be enabled for in-vehicle apps. When apps with this HMI type are activated, the HMI should make the web page of this app visible on the screen. This web page will become the main window of the application. The window capabilities of this open main window will be empty except for the window ID and physical button capabilities. `Show` requests that address the main window won't have any effect on the HMI. If the app sends this request, Core should return an unsuccessful response with the result code `RESOURCE_NOT_AVAILABLE`. The info field should note that the app is registered with projection mode enabled.
+The solution is based on a new template and a new App HMI type.
+
+### 1. Template `WEB_VIEW`
+
+A new template called `WEB_VIEW` should be added. This template should have the following restrictions:
+1. It's supported for in-vehicle WebEngine apps only.
+2. It's available only to the main window. It should not be available for widgets.
+3. It is only available to applications that successfully registered with the new App HMI type (see below section regarding new App HMI Type).
+
+If this template is used by WebEngine apps, the HMI of the IVI should present the WebEngine app and show the application's web page. 
+The application can control the web `document` object using JavaScript code to manipulate the document object model of the WebEngine app. 
+The HMI should respect the WebEngine app as the first responder to touch events. This means that touchable elements in the `document` should be accessible through the system's touch screen to the user.
 
 ![Screenshot example of a web app](../assets/proposals/0273-webengine-projection-mode/web-app-example.jpg)
 
 > Example of a local web app presenting the user interface with the WebView.
 
-Widgets are still available and can be controlled using `Show` RPC. Any overlay like Alert, ChoiceSets, Slider etc. are also available to the application.
+#### 1.1. Window Capabilities
 
-##### Policy control
+As of today, the HMI sends notifications of `OnSystemCapiblityUpdated` to the application to inform about the (main) window capabilities. 
+These capabilities are dependent of the currently used template. The application can change to any of the available templates as per current window capabilities. 
+Whenever the application changes the template, the HMI should send a new notification with the current template capabilities. 
+Generally, the window capabilities should refer to available text and image fields and should list the number of possible soft buttons and their capabilities.
 
-The HMI type `PROJECTION` is policy controlled. On the policy server this HMI type can be added to the valid HMI type list per app ID. Only apps with permissions to use this HMI type would be allowed to register.
+If the `WEB_VIEW` template is currently active, the window capabilities change as the application is presenting content using the web document.
 
-##### User interface guidelines (Driver Distraction rules)
+The following text fields `mainField1`, `mainField2`, `mainField3`, `mainField4`, `statusBar`, `mediaClock` and `mediaTrack` should be used practically on all the base templates. 
+It is recommended that `WindowCapability.textFields` should not contain these text field names if the OEM has implemented the `WEB_VIEW` template without these text fields. 
+The text fields `menuName` and `templateTitle` should be included in the capabilities if these fields are visible on the HMI.
+
+The parameters `availableTemplates`, `buttonCapabilities`, `imageTypeSupported` are independent of the currently active template and should reflect the general capabilities of the window/system.
+
+#### 1.2. What about widgets?
+
+Widgets are not affected by this proposal. They are still available and can be controlled using `Show` RPC. Any overlay like Alert, ChoiceSets, Slider etc. are also available to the application.
+
+Widget that duplicate content from the main window should still be possible. Despite the window capability, the app should still be able to send `Show` requests with all the desired content. This content should be duplicated to these widgets.
+
+### 2. App HMI Type `WEB_VIEW`
+
+A new App HMI type `WEB_VIEW` should be added for in-vehicle WebEngine apps. This HMI type specifies that the application's initial template should be set to `WEB_VIEW` instead of `DEFAULT`. 
+When in-vehicle apps with this HMI type are activated, the HMI should make the web page of this app visible on the screen. This web page will become the main window of the application.
+
+#### 2.1. Policy control
+
+The HMI type `WEB_VIEW` should policy controlled. On the policy server this HMI type can be added to the valid HMI type list per app ID. 
+
+Only apps with permissions to use this HMI type would be allowed to register. If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
+It is required for applications to register with this App HMI type in order to use the `WEB_VIEW` template. Otherwise the `WEB_VIEW` template should not be available.
+
+#### 2.2. System context and event change
+
+Independent of the app presentation type, the HMI will continue to provide system context information from the app. An application which uses the projection mode should continue to receive `OnHMIStatus` notifications and SDL Core will still be notified about event changes.
+
+### 3. User interface guidelines (Driver Distraction rules)
 
 With the current depth of this proposal, the HMI type should be used by 1st party OEM apps only. With future proposals and workshops the SDLC could open the HMI type to 3rd party by creating and defining proper driver distraction and user interface guidelines.
 
@@ -48,20 +90,22 @@ At the time of this proposal being in review, a set of driver distraction rules 
 
 More items may be included in the ruleset as they become Driver Distraction affected.
 
-##### System context and event change
-
-Independent of the app presentation type, the HMI will continue to provide system context information from the app. An application which uses the projection mode should continue to receive `OnHMIStatus` notifications and SDL Core will still be notified about event changes.
-
-Different to mobile app projection mode, in-vehicle apps won't be streaming video to the IVI, therefore the app and the library wouldn't listen for `OnHMIStatus.videoStreamingState` parameter to start presenting the app UI through the WebView.
-
 ## Potential downsides
 
 The same downsides apply as for [SDL 0031 Mobile Projection](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0031-mobile-projection.md) 
 
+The proposal states:
+
+> If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
+
+This can be seen as a downside as it could break with apps being used for the first time. This feature would require the IVI to implement policy table updates through the vehicle modem instead of using a mobile application. It also requires the HMI to use `SetAppProperties` upon app installation to add the app policy ID to the policy table in order to trigger the policy table update through the mode.
+
 ## Impact on existing code
 
-To the author's knowledge there is no impact to existing code unless there are barriers implemented in SDL Core preventing an in-vehicle app from registering with the `PROJECTION` HMI type.
+As a new enum element is added to the `AppHMIType` enum other platforms have impact by this very minor change. 
+Core would need to specially treat apps with this HMI type as they are not allowed to register unless permission was granted.
+Possibly SDL Server and SHAID are affected as HMI types are part of the policy system.
 
 ## Alternatives considered
 
-There are no alternatives available that the author feels competitive to the projection mode using a WebView.
+There are no alternatives available that the author feels competitive to a WebView.

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -49,7 +49,7 @@ The HMI should respect the WebEngine app as the first responder to touch events.
 
 #### 1.1. Window Capabilities
 
-As of today, the HMI sends notifications of `OnSystemCapiblityUpdated` to the application to inform about the (main) window capabilities. 
+As of today, the HMI sends notifications of `OnSystemCapabilityUpdated` to the application to inform about the (main) window capabilities. 
 These capabilities are dependent of the currently used template. The application can change to any of the available templates as per current window capabilities. 
 Whenever the application changes the template, the HMI should send a new notification with the current template capabilities. 
 Generally, the window capabilities should refer to available text and image fields and should list the number of possible soft buttons and their capabilities.

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -8,7 +8,7 @@
 ## Introduction
 
 This proposal is created based on discussion in https://github.com/smartdevicelink/sdl_evolution/issues/767.
-It extends [SDl-0240 - WebEngine support for SDL JavaScript](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0240-sdl-js-pwa.md) with a projection mode (formerly known as OpenHMI) that was introduced with [SDL-0031 Mobile Projection](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0031-mobile-projection.md).
+It extends [SDl-0240 - WebEngine support for SDL JavaScript](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0240-sdl-js-pwa.md) to allow using the WebEngine app's web view for the HMI in addition to the other available SDL templates. 
 
 ## Motivation
 

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -71,7 +71,8 @@ Widgets that duplicate content from the main window should still be possible. De
 ### 2. App HMI Type `WEB_VIEW`
 
 A new App HMI type `WEB_VIEW` should be added for in-vehicle WebEngine apps. This HMI type specifies that the application's initial template should be set to `WEB_VIEW` instead of `DEFAULT`. 
-When in-vehicle apps with this HMI type are activated, the HMI should make the web page of this app visible on the screen. This web page will become the main window of the application.
+As a result, when in-vehicle apps with this HMI type are activated, the HMI should make the web page of this app visible on the screen. This web page will become the main window of the application.
+
 
 **HMI_API**
 

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0273](0273-webengine-projection-mode.md)
 * Author: [Kujtim Shala](https://github.com/kshala-ford)
 * Status: **Returned for Revisions**
-* Impacted Platforms: [ Core / JavaScript Suite / Java Suite / iOS / RPC ]
+* Impacted Platforms: [ Core / JavaScript Suite / Java Suite / iOS / RPC / SDL Server / SHAID ]
 
 ## Introduction
 
@@ -14,7 +14,7 @@ It extends [SDl-0240 - WebEngine support for SDL JavaScript](https://github.com/
 
 This proposal describes a feature made possible using a WebEngine. A WebEngine can come with a web page rendering component described as a WebView in this proposal. The proposal describes how apps based on a WebEngine can be presented not only using system templates but that can control the WebView using the app's document object.
 
-The author and the SDLC member believe there are plenty of SDL features that are useful for WebEngine applications that use the proposed feature. The most important items are app policy management and app lifecycle. We would like to streamline the implementation to manage activating apps, deactivating or closing apps or run apps in background. Besides the benefits for us implementing web apps, it's also beneficial for the web app developer to use all the SDL features like app services, remote control, vehicle data widgets and many more.
+The author and the SDLC member believe there are plenty of SDL features that are useful for WebEngine applications that use the proposed feature. The most important items are app policy management and app lifecycle. We would like to streamline the implementation to manage activating apps, deactivating apps, closing apps or running apps in background. Besides the benefits for us implementing web apps, it's also beneficial for the web app developer to use all the SDL features like app services, remote control, vehicle data widgets and many more.
 
 ## Proposed solution
 
@@ -35,8 +35,8 @@ The HMI should respect the WebEngine app as the first responder to touch events.
 <enum name="PredefinedLayout" platform="documentation" since="3.0">
     <element name="WEB_VIEW" rootscreen="true" since="6.x">
         <description>
-            Custom root template allowing in-vehicle WebEngine applications with permissions to `WEB_VIEW`
-            show the applications own web view.
+            Custom root template allowing in-vehicle WebEngine applications with
+            appropriate permissions to show the application's own web view.
         </description>
     </element>
     :
@@ -60,13 +60,13 @@ The following text fields `mainField1`, `mainField2`, `mainField3`, `mainField4`
 It is recommended that `WindowCapability.textFields` should not contain these text field names if the OEM has implemented the `WEB_VIEW` template without these text fields. 
 The text fields `menuName` and `templateTitle` should be included in the capabilities if these fields are visible on the HMI.
 
-The parameters `availableTemplates`, `buttonCapabilities`, `imageTypeSupported` are independent of the currently active template and should reflect the general capabilities of the window/system.
+The parameters `availableTemplates`, `buttonCapabilities`, and `imageTypeSupported` are independent of the currently active template and should reflect the general capabilities of the window/system.
 
 #### 1.2. What about widgets?
 
 Widgets are not affected by this proposal. They are still available and can be controlled using `Show` RPC. Any overlay like Alert, ChoiceSets, Slider etc. are also available to the application.
 
-Widget that duplicate content from the main window should still be possible. Despite the window capability, the app should still be able to send `Show` requests with all the desired content. This content should be duplicated to these widgets.
+Widgets that duplicate content from the main window should still be possible. Despite the window capability, the app should still be able to send `Show` requests with all the desired content. This content should be duplicated to these widgets.
 
 ### 2. App HMI Type `WEB_VIEW`
 
@@ -93,7 +93,7 @@ When in-vehicle apps with this HMI type are activated, the HMI should make the w
 
 #### 2.1. Policy control
 
-The HMI type `WEB_VIEW` should policy controlled. On the policy server this HMI type can be added to the valid HMI type list per app ID. 
+The HMI type `WEB_VIEW` should be policy controlled. On the policy server this HMI type can be added to the valid HMI type list per app ID.
 
 Only apps with permissions to use this HMI type would be allowed to register. If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
 It is required for applications to register with this App HMI type in order to use the `WEB_VIEW` template. Otherwise the `WEB_VIEW` template should not be available.
@@ -122,7 +122,7 @@ At the time of this proposal being in review, a set of driver distraction rules 
 
 More items may be included in the ruleset as they become Driver Distraction affected.
 
-### 4. Application lifecycle (or what happens if the app is closed?)
+### 4. Application lifecycle (or, what happens if the app is closed?)
 
 When an app is deactivated into HMI level NONE, the connection to Core can stay open as long as there is a way for the HMI to be able to unregister and disconnect an app in case of performance issues. Performance issues can be due to high CPU load or memory warnings. This requires a new exit reason that can be used by the HMI and will be forwarded to the app. 
 
@@ -158,7 +158,7 @@ This can be seen as a downside as it could break with apps being used for the fi
 
 ## Impact on existing code
 
-As a new enum element is added to the `AppHMIType` enum other platforms have impact by this very minor change. 
+As a new enum element is added to the `AppHMIType` enum, other platforms are impacted by this very minor change.
 Core would need to specially treat apps with this HMI type as they are not allowed to register unless permission was granted.
 Possibly SDL Server and SHAID are affected as HMI types are part of the policy system.
 

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -8,11 +8,13 @@
 ## Introduction
 
 This proposal is created based on discussion in https://github.com/smartdevicelink/sdl_evolution/issues/767.
-It extends [SDl-0240 - WebEngine support for SDL JavaScript](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0240-sdl-js-pwa.md) to allow using the WebEngine app's web view for the HMI in addition to the other available SDL templates. 
+It extends [SDl-0240 - WebEngine support for SDL JavaScript](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0240-sdl-js-pwa.md) to allow using the WebEngine app's web view for the HMI in addition to the other available SDL templates.
 
 ## Motivation
 
 This proposal describes a feature made possible using a WebEngine. A WebEngine can come with a web page rendering component described as a WebView in this proposal. The proposal describes how apps based on a WebEngine can be presented not only using system templates but that can control the WebView using the app's document object.
+
+The author and the SDLC member believe there are plenty of SDL features that are useful for WebEngine applications that use the proposed feature. The most important items are app policy management and app lifecycle. We would like to streamline the implementation to manage activating apps, deactivating or closing apps or run apps in background. Besides the benefits for us implementing web apps, it's also beneficial for the web app developer to use all the SDL features like app services, remote control, vehicle data widgets and many more.
 
 ## Proposed solution
 
@@ -28,6 +30,18 @@ A new template called `WEB_VIEW` should be added. This template should have the 
 If this template is used by WebEngine apps, the HMI of the IVI should present the WebEngine app and show the application's web page. 
 The application can control the web `document` object using JavaScript code to manipulate the document object model of the WebEngine app. 
 The HMI should respect the WebEngine app as the first responder to touch events. This means that touchable elements in the `document` should be accessible through the system's touch screen to the user.
+
+```xml
+<enum name="PredefinedLayout" platform="documentation" since="3.0">
+    <element name="WEB_VIEW" rootscreen="true" since="6.x">
+        <description>
+            Custom root template allowing in-vehicle WebEngine applications with permissions to `WEB_VIEW`
+            show the applications own web view.
+        </description>
+    </element>
+    :
+</enum>
+```
 
 ![Screenshot example of a web app](../assets/proposals/0273-webengine-projection-mode/web-app-example.jpg)
 
@@ -58,6 +72,24 @@ Widget that duplicate content from the main window should still be possible. Des
 
 A new App HMI type `WEB_VIEW` should be added for in-vehicle WebEngine apps. This HMI type specifies that the application's initial template should be set to `WEB_VIEW` instead of `DEFAULT`. 
 When in-vehicle apps with this HMI type are activated, the HMI should make the web page of this app visible on the screen. This web page will become the main window of the application.
+
+**HMI_API**
+
+```xml
+<enum name="AppHMIType">
+    :
+    <element name="WEB_VIEW" />
+</enum>
+```
+
+**MOBILE_API**
+
+```xml
+<enum name="AppHMIType" since="2.0">
+    :
+    <element name="WEB_VIEW" since="6.3" />
+</enum>
+```
 
 #### 2.1. Policy control
 
@@ -90,9 +122,33 @@ At the time of this proposal being in review, a set of driver distraction rules 
 
 More items may be included in the ruleset as they become Driver Distraction affected.
 
+### 4. Application lifecycle (or what happens if the app is closed?)
+
+When an app is deactivated into HMI level NONE, the connection to Core can stay open as long as there is a way for the HMI to be able to unregister and disconnect an app in case of performance issues. Performance issues can be due to high CPU load or memory warnings. This requires a new exit reason that can be used by the HMI and will be forwarded to the app. 
+
+**HMI_API**
+
+```xml
+<enum name="ApplicationExitReason">
+    :
+    <element name="RESOURCE_CONSTRAINT">
+        <description>By getting this value, SDL should unregister the application to allow the HMI to close the application.</description>
+    </element>
+</enum>
+```
+
+**MOBILE_API**
+
+```xml
+<enum name="AppInterfaceUnregisteredReason" since="1.0">
+    :
+    <element name="RESOURCE_CONSTRAINT" since="6.x" />
+</enum>
+```
+
 ## Potential downsides
 
-The same downsides apply as for [SDL 0031 Mobile Projection](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0031-mobile-projection.md) 
+The same downsides apply as for [SDL 0031 Mobile Projection](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0031-mobile-projection.md) because WebEngine applications that use the web view are responsible just as any projection or mobile navigation application.
 
 The proposal states:
 

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -1,7 +1,7 @@
 # WebEngine Projection mode
 
 * Proposal: [SDL-0273](0273-webengine-projection-mode.md)
-* Author: [Kujtim Shala](https://github.com/kshala-ford)
+* Author: [Kujtim Shala](https://github.com/kshala-ford), [Markos Rapitis](https://github.com/mrapitis) and [Andriy Byzhynar](https://github.com/abyzhynar)
 * Status: **Returned for Revisions**
 * Impacted Platforms: [ Core / JavaScript Suite / Java Suite / iOS / RPC / SDL Server / SHAID ]
 

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0273](0273-webengine-projection-mode.md)
 * Author: [Kujtim Shala](https://github.com/kshala-ford)
 * Status: **Returned for Revisions**
-* Impacted Platforms: [ Core / JavaScript / RPC ]
+* Impacted Platforms: [ Core / JavaScript Suite / Java Suite / iOS / RPC ]
 
 ## Introduction
 


### PR DESCRIPTION
This proposal is created based on discussion in https://github.com/smartdevicelink/sdl_evolution/issues/767.
It extends [SDl-0240 - WebEngine support for SDL JavaScript](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0240-sdl-js-pwa.md) to allow using the WebEngine app's web view for the HMI in addition to the other available SDL templates.