### PR TITLE
Revise 0255-Enhance BodyInformation vehicle data

### DIFF
--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -26,7 +26,7 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 * `rearLeftDoorAjar`
 * `rearRightDoorAjar`
 
-We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status(`CLOSED/LOCKED/AJAR/REMOVED`). Roof can be a convertible roof, sunroof/moonroof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide appropriate values. For example:
+We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status (`CLOSED/LOCKED/AJAR/REMOVED`). Roof can be a convertible roof, sunroof/moonroof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide appropriate values. For example:
 
 * Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `AJAR` with corresponding `state`. 
 * Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `AJAR` with corresponding `state`.

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -11,7 +11,7 @@ This proposal is to enhance `BodyInformation` with more params to get access to 
 
 ## Motivation
 
-In order to partner with more diverse app partners, we need to provide additional sets of vehicle data items through SDL. This goes in line with commitment to enhance SDL with even richer vehicle data content. We need to provide apps with doors' lock status along with if trunk/liftgate or hood/bonnet are ajar. This information is handy for all the apps but in particular the apps which provide safety information and insurance.
+In order to partner with more diverse app partners, we need to provide additional sets of vehicle data items through SDL. This goes in line with commitment to enhance SDL with even richer vehicle data content. We need to provide apps with doors' lock status, roof status and status for trunk/liftgate or hood/bonnet. This information is handy for all the apps but in particular the apps which provide safety information and insurance.
 
 ## Proposed Solution 
 
@@ -24,6 +24,12 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 * `passengerDoorAjar`
 * `rearLeftDoorAjar`
 * `rearRightDoorAjar`
+
+We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status. Roof can be a convertible roof, sun/moon roof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide approproate values. For example:
+
+* Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `OPEN` with corresponding `state`. 
+* Sun/Moon roof - `location` grid would span just actual location of sun/moon roof. `status` could be `CLOSED` or `OPEN` with corresponding `state`.
+* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `PRESENT`. `state` can be omitted.
 
 #### Updates in MOBILE_API:
 
@@ -41,6 +47,10 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 	<element name="CLOSED"/>
 	<element name="LOCKED"/>
 	<element name="AJAR"/>
++	<element name="REMOVED"/>
++	<element name="PRESENT"/>
++	<element name="OPEN"/>
++	<element name="UNLOCKED"/>
 </enum>
 ```
 
@@ -50,6 +60,19 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 	<description>Describes the status of a parameter of trunk/hood/etc.</description>
 	<param name="location" type="Grid" mandatory="true"/>
 	<param name="status" type="DoorStatusType" mandatory="true"/>
+</struct>
+```
+
+##### New Struct RoofStatus is needed:
+```xml
+<struct name="RoofStatus" since="X.x">
+	<description>
+		Describes the status of a parameter of roof, convertible roof, sun/moon roof etc.
+		If roof is open, state will determine percentage of roof open.
+	</description>
+	<param name="location" type="Grid" mandatory="true"/>
+	<param name="status" type="DoorStatusType" mandatory="true"/>
+	<param name="state" type="WindowState" mandatory="false"/>
 </struct>
 ```
 
@@ -83,6 +106,9 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 +	<param name="gateStatuses" type="GateStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
 +		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
 +	</param>
++	<param name="roofStatuses" type="RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
++		<description>Provides status for roof/convertible roof/Sunroof etc. if Closed/Open</description>
++	</param>
 </struct>
 ```
 
@@ -91,7 +117,7 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 
 ##### New Struct `DoorStatus` is needed in `Common` interface:
 ```xml
-<struct name="DoorStatus" since="X.x">
+<struct name="DoorStatus">
 	<description>Describes the status of a parameter of door.</description>
 	<param name="location" type="Common.Grid" mandatory="true"/>
 	<param name="status" type="Common.DoorStatusType" mandatory="true"/>
@@ -99,25 +125,42 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 ```
 ##### New enum `DoorStatusType` is needed in `Common` interface:
 ```xml
-<enum name="DoorStatusType" since="X.x">
+<enum name="DoorStatusType">
 	<element name="CLOSED"/>
 	<element name="LOCKED"/>
 	<element name="AJAR"/>
++	<element name="REMOVED"/>
++	<element name="PRESENT"/>
++	<element name="OPEN"/>
++	<element name="UNLOCKED"/>
 </enum>
 ```
 
 ##### New Struct `GateStatus` is needed in `Common` interface:
 ```xml
-<struct name="GateStatus" since="X.x">
+<struct name="GateStatus">
 	<description>Describes the status of a parameter of trunk/hood/etc.</description>
 	<param name="location" type="Common.Grid" mandatory="true"/>
 	<param name="status" type="Common.DoorStatusType" mandatory="true"/>
 </struct>
 ```
 
+##### New Struct RoofStatus is needed in `Common` interface:
+```xml
+<struct name="RoofStatus">
+	<description>
+		Describes the status of a parameter of roof, convertible roof, sun/moon roof etc.
+		If roof is open, state will determine percentage of roof open.
+	</description>
+	<param name="location" type="Common.Grid" mandatory="true"/>
+	<param name="status" type="Common.DoorStatusType" mandatory="true"/>
+	<param name="state" type="Common.WindowState" mandatory="false"/>
+</struct>
+```
+
 ##### Then `BodyInformation` Struct in `Common` interface would be updated as:
 ```xml
-<struct name="BodyInformation" since="2.0">
+<struct name="BodyInformation">
 	<param name="parkBrakeActive" type="Boolean" mandatory="true">
 		<description>If mechanical park brake is active, true. Otherwise false.</description>
 	</param>
@@ -127,23 +170,26 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 	<param name="ignitionStatus" type="Common.IgnitionStatus" mandatory="true">
 		<description>Provides information on current ignitiion status. See IgnitionStatus.</description>
 	</param>
-	<param name="driverDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
+	<param name="driverDoorAjar" type="Boolean" mandatory="false">
 		<description>References signal "DrStatDrv_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
 	</param>
-	<param name="passengerDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
+	<param name="passengerDoorAjar" type="Boolean" mandatory="false">
 		<description>References signal "DrStatPsngr_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
 	</param>
-	<param name="rearLeftDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
+	<param name="rearLeftDoorAjar" type="Boolean" mandatory="false">
 		<description>References signal "DrStatRl_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
 	</param>
-	<param name="rearRightDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
+	<param name="rearRightDoorAjar" type="Boolean" mandatory="false">
 		<description>References signal "DrStatRr_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
 	</param>
-+	<param name="doorStatuses" type="Common.DoorStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
++	<param name="doorStatuses" type="Common.DoorStatus" array="true" minsize="0" maxsize="100" mandatory="false">
 +		<description>Provides status for doors if Ajar/Closed/Locked</description>
 +	</param>	
-+	<param name="gateStatuses" type="Common.GateStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
++	<param name="gateStatuses" type="Common.GateStatus" array="true" minsize="0" maxsize="100" mandatory="false">
 +		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
++	</param>
++	<param name="roofStatuses" type="Common.RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false">
++		<description>Provides status for roof/convertible roof/Sunroof etc. if Closed/Open</description>
 +	</param>
 </struct>
 ```

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -26,11 +26,12 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 * `rearLeftDoorAjar`
 * `rearRightDoorAjar`
 
-We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status. Roof can be a convertible roof, sunroof/moonroof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide appropriate values. For example:
+We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status(`CLOSED/LOCKED/AJAR/REMOVED`). Roof can be a convertible roof, sunroof/moonroof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide appropriate values. For example:
 
-* Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `OPEN` with corresponding `state`. 
-* Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `OPEN` with corresponding `state`.
-* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `PRESENT`. `state` can be omitted.
+* Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `AJAR` with corresponding `state`. 
+* Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `AJAR` with corresponding `state`.
+* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.
+
 
 #### Updates in MOBILE_API:
 
@@ -49,9 +50,6 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 	<element name="LOCKED"/>
 	<element name="AJAR"/>
 +	<element name="REMOVED"/>
-+	<element name="PRESENT"/>
-+	<element name="OPEN"/>
-+	<element name="UNLOCKED"/>
 </enum>
 ```
 
@@ -69,7 +67,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 <struct name="RoofStatus" since="X.x">
 	<description>
 		Describes the status of a parameter of roof/convertible roof/sunroof/moonroof etc.
-		If roof is open, state will determine percentage of roof open.
+		If roof is open(AJAR), state will determine percentage of roof open.
 	</description>
 	<param name="location" type="Grid" mandatory="true"/>
 	<param name="status" type="DoorStatusType" mandatory="true"/>
@@ -108,7 +106,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 +		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
 +	</param>
 +	<param name="roofStatuses" type="RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
-+		<description>Provides status for roof/convertible roof/sunroof/moonroof etc., if Closed/Open/Present/Removed etc.</description>
++		<description>Provides status for roof/convertible roof/sunroof/moonroof etc., if Closed/Ajar/Removed etc.</description>
 +	</param>
 </struct>
 ```
@@ -131,9 +129,6 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 	<element name="LOCKED"/>
 	<element name="AJAR"/>
 +	<element name="REMOVED"/>
-+	<element name="PRESENT"/>
-+	<element name="OPEN"/>
-+	<element name="UNLOCKED"/>
 </enum>
 ```
 
@@ -151,7 +146,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 <struct name="RoofStatus">
 	<description>
 		Describes the status of a parameter of roof, convertible roof, sunroof/moonroof etc.
-		If roof is open, state will determine percentage of roof open.
+		If roof is open(AJAR), state will determine percentage of roof open.
 	</description>
 	<param name="location" type="Common.Grid" mandatory="true"/>
 	<param name="status" type="Common.DoorStatusType" mandatory="true"/>
@@ -190,7 +185,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 +		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
 +	</param>
 +	<param name="roofStatuses" type="Common.RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false">
-+		<description>Provides status for roof/convertible roof/sunroof/moonroof etc., if Closed/Open/Present/Removed etc.</description>
++		<description>Provides status for roof/convertible roof/sunroof/moonroof etc., if Closed/Ajar/Removed etc.</description>
 +	</param>
 </struct>
 ```

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -30,7 +30,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 
 * Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `AJAR` with corresponding `state`. 
 * Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `AJAR` with corresponding `state`.
-* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.
+* Entire roof - `location` grid would span entire rows and columns and roof status would be `REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.
 
 
 #### Updates in MOBILE_API:
@@ -67,7 +67,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 <struct name="RoofStatus" since="X.x">
 	<description>
 		Describes the status of a parameter of roof/convertible roof/sunroof/moonroof etc.
-		If roof is open(AJAR), state will determine percentage of roof open.
+		If roof is open (AJAR), state will determine percentage of roof open.
 	</description>
 	<param name="location" type="Grid" mandatory="true"/>
 	<param name="status" type="DoorStatusType" mandatory="true"/>
@@ -146,7 +146,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 <struct name="RoofStatus">
 	<description>
 		Describes the status of a parameter of roof, convertible roof, sunroof/moonroof etc.
-		If roof is open(AJAR), state will determine percentage of roof open.
+		If roof is open (AJAR), state will determine percentage of roof open.
 	</description>
 	<param name="location" type="Common.Grid" mandatory="true"/>
 	<param name="status" type="Common.DoorStatusType" mandatory="true"/>
@@ -199,9 +199,9 @@ Some parameters are deprecated.
 * SDL Core needs to be updated as per new API.
 * iOS/Java Suite need to be updated to support getters/setters as per new API.
 * HMI needs to be updated to support new vehicle data params.
-* HMI guidelines need updates.
+* HMI Integration Guidelines need updates.
 
-### HMI guidelines additions:
+### HMI Integration Guidelines additions:
 
 #### Door `status` selection:
 
@@ -213,10 +213,10 @@ Some parameters are deprecated.
 | Door is open  | AJAR  |
 | Door is physically removed  | REMOVED  |
 
-#### Rood `status` selection:
+#### Roof `status` selection:
 * Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `AJAR` with corresponding `state`. 
 * Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `AJAR` with corresponding `state`.
-* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.
+* Entire roof - `location` grid would span entire rows and columns and roof status would be `REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.
 * Other type of roof - `location` grid would span actual location of the roof as per physical location. `status` and `state` would be as per table below:
 
 | Roof condition  | `status` | `state` |

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -29,7 +29,7 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status. Roof can be a convertible roof, sunroof/moonroof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide appropriate values. For example:
 
 * Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `OPEN` with corresponding `state`. 
-* Sunroof/Moonroof - `location` grid would span just actual location of sun/moon roof. `status` could be `CLOSED` or `OPEN` with corresponding `state`.
+* Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `OPEN` with corresponding `state`.
 * Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `PRESENT`. `state` can be omitted.
 
 #### Updates in MOBILE_API:

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -18,6 +18,7 @@ In order to partner with more diverse app partners, we need to provide additiona
 Following vehicle data params are added to `BodyInformation` struct:
 * `doorsStatus`
 * `gatesStatus`
+* `roofStatuses`
 
 Following vehicle data params are deprecated from `BodyInformation` struct:
 * `driverDoorAjar`

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -199,6 +199,33 @@ Some parameters are deprecated.
 * SDL Core needs to be updated as per new API.
 * iOS/Java Suite need to be updated to support getters/setters as per new API.
 * HMI needs to be updated to support new vehicle data params.
+* HMI guidelines need updates.
+
+### HMI guidelines additions:
+
+#### Door `status` selection:
+
+| Door condition  | `status` |
+| ------------- | ------------- |
+| Door is closed and locked  | LOCKED  |
+| Door is closed and unlocked  | CLOSED  |
+| Door is closed and unknown locked state | CLOSED  |
+| Door is open  | AJAR  |
+| Door is physically removed  | REMOVED  |
+
+#### Rood `status` selection:
+* Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `AJAR` with corresponding `state`. 
+* Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `AJAR` with corresponding `state`.
+* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.
+* Other type of roof - `location` grid would span actual location of the roof as per physical location. `status` and `state` would be as per table below:
+
+| Roof condition  | `status` | `state` |
+| ------------- | ------------- | ------------- |
+| Roof is closed and locked  | LOCKED  | `approximatePosition` = 0 & `deviation` = 0 |
+| Roof is closed and unlocked  | CLOSED  | `approximatePosition` = 0 & `deviation` = 0 |
+| Roof is closed and unknown locked state | CLOSED  | `approximatePosition` = 0 & `deviation` = 0 |
+| Roof is open  | AJAR  | actual values of `approximatePosition` & `deviation` |
+| Roof is physically removed  | REMOVED  | can be omitted OR `approximatePosition` = 0 & `deviation` = 0 |
 
 ## Alternatives considered
 

--- a/proposals/0255-Enhance-BodyInformation-vehicle-data.md
+++ b/proposals/0255-Enhance-BodyInformation-vehicle-data.md
@@ -26,10 +26,10 @@ Following vehicle data params are deprecated from `BodyInformation` struct:
 * `rearLeftDoorAjar`
 * `rearRightDoorAjar`
 
-We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status. Roof can be a convertible roof, sun/moon roof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide approproate values. For example:
+We are going to use `location` to locate a door, a gate or a roof component. For Door and Gate, `location` would utilize `Grid` to locate/span the actual location of the Door or Gate while `status` provides appropriate status. Roof can be a convertible roof, sunroof/moonroof or simply a removable roof. Based on roof type, parameters `location`, `state` and `status` need to provide appropriate values. For example:
 
 * Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `OPEN` with corresponding `state`. 
-* Sun/Moon roof - `location` grid would span just actual location of sun/moon roof. `status` could be `CLOSED` or `OPEN` with corresponding `state`.
+* Sunroof/Moonroof - `location` grid would span just actual location of sun/moon roof. `status` could be `CLOSED` or `OPEN` with corresponding `state`.
 * Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `PRESENT`. `state` can be omitted.
 
 #### Updates in MOBILE_API:
@@ -64,11 +64,11 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 </struct>
 ```
 
-##### New Struct RoofStatus is needed:
+##### New Struct `RoofStatus` is needed:
 ```xml
 <struct name="RoofStatus" since="X.x">
 	<description>
-		Describes the status of a parameter of roof, convertible roof, sun/moon roof etc.
+		Describes the status of a parameter of roof/convertible roof/sunroof/moonroof etc.
 		If roof is open, state will determine percentage of roof open.
 	</description>
 	<param name="location" type="Grid" mandatory="true"/>
@@ -108,7 +108,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 +		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
 +	</param>
 +	<param name="roofStatuses" type="RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
-+		<description>Provides status for roof/convertible roof/Sunroof etc. if Closed/Open</description>
++		<description>Provides status for roof/convertible roof/sunroof/moonroof etc., if Closed/Open/Present/Removed etc.</description>
 +	</param>
 </struct>
 ```
@@ -146,11 +146,11 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 </struct>
 ```
 
-##### New Struct RoofStatus is needed in `Common` interface:
+##### New Struct `RoofStatus` is needed in `Common` interface:
 ```xml
 <struct name="RoofStatus">
 	<description>
-		Describes the status of a parameter of roof, convertible roof, sun/moon roof etc.
+		Describes the status of a parameter of roof, convertible roof, sunroof/moonroof etc.
 		If roof is open, state will determine percentage of roof open.
 	</description>
 	<param name="location" type="Common.Grid" mandatory="true"/>
@@ -190,7 +190,7 @@ We are going to use `location` to locate a door, a gate or a roof component. For
 +		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
 +	</param>
 +	<param name="roofStatuses" type="Common.RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false">
-+		<description>Provides status for roof/convertible roof/Sunroof etc. if Closed/Open</description>
++		<description>Provides status for roof/convertible roof/sunroof/moonroof etc., if Closed/Open/Present/Removed etc.</description>
 +	</param>
 </struct>
 ```


### PR DESCRIPTION
## Introduction

This revision adds `roofStatuses` param to `BodyInformation` struct along with supporting enums and structs. These additions would enhance existing `doorStatuses` param as well. Also the original proposal needs to be updated to remove `deprecated` field from params in `BodyInformation` struct in HMI API as it is not applicable there. The deprecated field and information is kept in MOBILE API.

## Motivation

`BodyInformation` is missing the details for roof, convertible, sunroof/moonroof, removable roof etc. Current `DoorStatusType` enum also needs some more elements to support additional possible values for `status`.

## Proposed solution
### New Struct `RoofStatus` is needed:
```xml
<struct name="RoofStatus">
	<description>
		Describes the status of a parameter of removable roof/convertible roof/sunroof/moonroof etc.
		If roof is open(AJAR), state will determine percentage of roof open.
	</description>
	<param name="location" type="Grid" mandatory="true"/>
	<param name="status" type="DoorStatusType" mandatory="true"/>
	<param name="state" type="WindowState" mandatory="false"/>
</struct>
```
We can use the same grid method to locate the roof and decide its span, e.g.:
* Convertible roof - `location` grid would span entire rows and columns and roof `status` could be `CLOSED` or `AJAR` with corresponding `state`. 
* Sunroof/Moonroof - `location` grid would span just actual location of sunroof/moonroof. `status` could be `CLOSED` or `AJAR` with corresponding `state`.
* Entire roof - `location` grid would span entire rows and columns and roof status would be`REMOVED` or `CLOSED/LOCKED`. `state` can be omitted.

### Enum `DoorStatusType` is updated:
```xml
<enum name="DoorStatusType">
	<element name="CLOSED"/>
	<element name="LOCKED"/>
	<element name="AJAR"/>
+	<element name="REMOVED"/>
</enum>
```

### Then `BodyInformation` struct would be updated as:
```xml
<struct name="BodyInformation" since="2.0">
	<param name="parkBrakeActive" type="Boolean" mandatory="true">
		<description>If mechanical park brake is active, true. Otherwise false.</description>
	</param>
	<param name="ignitionStableStatus" type="IgnitionStableStatus" mandatory="true">
		<description>Provides information on status of ignition stable switch. See IgnitionStableStatus.</description>
	</param>
	<param name="ignitionStatus" type="IgnitionStatus" mandatory="true">
		<description>Provides information on current ignitiion status. See IgnitionStatus.</description>
	</param>
	<param name="driverDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
		<description>References signal "DrStatDrv_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
	</param>
	<param name="passengerDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
		<description>References signal "DrStatPsngr_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
	</param>
	<param name="rearLeftDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
		<description>References signal "DrStatRl_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
	</param>
	<param name="rearRightDoorAjar" type="Boolean" mandatory="false" deprecated="true" since="X.x">
		<description>References signal "DrStatRr_B_Actl". Deprecated starting with RPC Spec X.x.x.</description>
	</param>
	<param name="doorStatuses" type="DoorStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
		<description>Provides status for doors if Ajar/Closed/Locked</description>
	</param>	
	<param name="gateStatuses" type="GateStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
		<description>Provides status for trunk/hood/etc. if Ajar/Closed/Locked</description>
	</param>
+	<param name="roofStatuses" type="RoofStatus" array="true" minsize="0" maxsize="100" mandatory="false" since="X.x">
+		<description>Provides status for roof/convertible roof/moonroof/sunroof etc. if Closed/Ajar/Removed etc.</description>
+	</param>
</struct>
```

## Potential downsides
None

## Impact on existing code
Same as original proposal

## Alternatives considered
None

