### PR TITLE
Revise 0298-Processing of unknown enum values by SDL Core

### DIFF
--- a/proposals/0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md
+++ b/proposals/0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md
@@ -1,52 +1,46 @@
-  # Processing of unknown enum values by SDL Core and Mobile Libraries
-  * Proposal: [SDL-0298](0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md)
-  * Authors: [Igor Gapchuk](https://github.com/IGapchuk), [Dmitriy Boltovskiy](https://github.com/dboltovskyi/), [Kostiantyn Boskin](https://github.com/kostyaboss), [Yurii Lokhmatov](https://github.com/yoooriii)
+  # Processing of unknown enum values by SDL Core
+  * Proposal: [SDL-0298](0298-Processing-of-unknown-enum-values-by-SDLCore.md)
+  * Authors: [Igor Gapchuk](https://github.com/IGapchuk), [Dmitriy Boltovskiy](https://github.com/dboltovskyi/)
   * Status: **Returned for Revisions**
-  * Impacted Platforms: [Core / iOS / JavaSuite]
+  * Impacted Platforms: [Core]
 
 ## Introduction
-The main purpose of this proposal is to gracefully handle incompatible enum values in a mobile RPC request with any given SDL Core version. This can be achieved by improving the way SDL Core processes and validates unknown enum values and by extending mobile library functionality to properly format RPC requests when RPC API’s (RAPI) are mismatched.
+The main purpose of this proposal is to gracefully handle unknown enum values from a mobile RPC request with any given SDL Core version. This can be achieved by improving the way SDL Core processes and validates unknown enum values.
 
 ## Motivation
 
-The current filtering and data validation mechanism used by SDL Core needs be improved upon to avoid application registration issues and other RPC failures that result from differences in RAPI versions between the SDL mobile library and SDL Core.  To maintain backwards compatibility, the mobile libraries also need to be updated to format RPC requests by cutting off or ignoring unknown and unsupported enum values when a difference in RAPI sets have been detected.
+The current filtering and data validation mechanism used by SDL Core needs be improved upon to issues related to possible differences in API versions between parameters in the request from a mobile application and an SDL Core.
 
-To better understand the issue at hand, please take note of the following example:
+To better understand what kinds of issues we could face, let's assume the next example:
 
-Let us assume that a mobile application with a newer version of the RAPI attempts to connect to an SDL Core instance which is using an older RAPI version. In this example, the SDL Core RAPI version is set to 4.3 whereas the mobile application RAPI version is set to 6.0. Let us also assume that the mobile application has an AppHMIType of DEFAULT and REMOTE_CONTROL set.  The DEFAULT AppHMIType has been present in the RAPI since its inception, however REMOTE_CONTROL was introduced in version 6.0 of the RAPI.
-
-In the case above, the mobile application will try to register itself by sending a RegisterAppInterface (RAI) request to SDL Core with an array of AppHMITypes : appHMIType[DEFAULT, REMOTE_CONTROL]. SDL Core will next try to validate the parameters in the RAI request, it will immediately find an unknown enum value of REMOTE_CONTROL. A failure response will then be sent to the mobile application with the INVALID_DATA result code (this is because the REMOTE_CONTROL AppHMIType has only been available since version RAPI 4.5, however we are communicating with a version of SDL Core that only supports RAPI 4.3). As a result of the scenario above, the mobile application fails to register with SDL Core providing an unacceptable user experience. In addition the mobile application cannot conclusively determine the cause of failure since INVALID_DATA can be returned for any number of reasons.  Ideally the mobile app would be registered successfully with a warning provided in the result code stating "some AppHMITypes could not be processed."
-
-To fix the case stated above as well as similar cases originating from the same cause, the validation logic inside of SDL Core should be updated to cutoff / ignore unknown enums present in RPC requests.  These failure cases should instead be replaced with SUCCESS cases with warnings result codes.
-To ensure backward compatibility with earlier versions of SDL Core, mobile libraries should be updated to process, filter and format enums inside of RPC requests when a difference in RAPI sets have been detected.
+A mobile device with a newer version of the API (5.0) during connecting to the SDL Core, which has an older API version (4.3), sends a `RegisterAppInterface` request to SDL Core with an array of `AppHMITypes` which has the next values: `[DEFAULT, REMOTE_CONTROL]` (The `AppHMIType::DEFAULT` was introduced in the API since 2.0 version, since the time the `AppHMIType` type was added into the API, and `AppHMIType::REMOTE_CONTROL` was introduced in the 4.5 version of the API). SDL Core tries to validate the parameters in the RAI request, finds an unknown enum value of `AppHMIType::REMOTE_CONTROL`. As a result, the SDL Core sends a failure response to a mobile application with the `INVALID_DATA` result code. Thus, the mobile application fails to register with SDL Core that is an unacceptable user experience. Besides, the mobile application cannot conclusively determine the cause of failure since `INVALID_DATA` can be returned for a line of reasons.
+With the changes provided by this proposal, SDL Core will be able to process all unknown enums in mobile requests in the correct way and respond to mobile applications with informative messages about happed failures.
 
 ## Proposed solution
 
-### SDL Core changes
-
-When SDL Core receives a request from a mobile application, it starts validation of all incoming parameters.
+When SDL Core receives a request from a mobile application, it starts the validation of all incoming parameters.
 If a parameter includes an unknown enum value, SDL Core has to cut off such value from the parameter.
 
   This means the following cases are possible:
 
-  1. Type of parameter is non-array enum (see example 1).
+  1. The type of parameter is a non-array enum (see example 1).
 
       SDL Core has to remove this parameter from the request since the value after cutting off becomes empty.
 
-  2. Parameter is an array of enum types (see example 2).
+  2. A parameter is an array of enum types (see example 2).
 
       SDL Core has to remove an unknown value from the array.
       A case is possible when all values are unknown and thus get removed.
       In this case, SDL Core has to proceed the same way as in case 1.
 
-  3. Parameter is part of the structure (see example 3).
+  3. A parameter is part of the structure (see example 3).
 
       SDL Core has to proceed the same way as in case #1 or #2 and remove this parameter from the structure.
       However, if the parameter is mandatory the structure becomes invalid.
       In this case, SDL Core has to remove the whole structure from the request.
       During this process, SDL Core has to proceed recursively from the very bottom level up to the top.
 
-  4. Parameter is a part of the structure which is a part of an array (see example 4).
+  4. A parameter is a part of the structure which is a part of an array (see example 4).
 
       SDL Core has to process it the same way as in case #3 and remove the structure as an item of the array.
       Once all the parameters are processed SDL Core has to proceed with the request as usual.
@@ -54,55 +48,67 @@ If a parameter includes an unknown enum value, SDL Core has to cut off such valu
   If at least one value of at least one parameter was cut off, SDL Core has to update the response to the mobile application as follows:
 
   1. If the response was processed successfully, SDL Core has to provide the `WARNINGS` result code instead of `SUCCESS`.
-  2. SDL Core has to provide removed enum items in `info` string of the response.
+  2. SDL Core has to provide removed enum items in the `info` string of the response.
 
       Since there could be more than one parameter with cut-off value, `info` message can be constructed the following way:
 
       `Invalid enums were removed: <param_1>:<enum_value_1>,<enum_value_2>;<param_2>:<enum_value_3> ...`
 
-      If `info` parameter contains other value(s) belonging to the original processing result SDL Core has to append information about cut-off enum value(s) to the existing value.
+      If the `info` parameter contains other value(s) belonging to the original processing result SDL Core has to append information about cut-off enum value(s) to the existing value.
 
   **Examples:**
+
   In each example below the mobile application sends a request to SDL Core.
-  1. Request contains a parameter which value is an enum item.
+
+  **NOTE**
+
+  To determine the API version for choosing if a parameter is mandatory should be used the negotiated API version.
+
+  In the case when Mobile Application has the 7.0 API version and the SDL Core has the 6.0 API version, the negotiated API version will be 6.0 (the version of the SDL Core).
+
+  In the case when Mobile Application has the 6.0 API version and the SDL Core has the 7.0 API version, the negotiated API version will be 6.0 (the version of the Mobile Application).
+
+  Negotiated API version is the version that should be used for determining if a parameter is mandatory or not, as mandatory=true/false can change between different APIs versions
+
+  1. The request contains a parameter which value is an enum item.
 
       Request: `SetMediaClockTimer`
 
       1.1 Parameter is mandatory: `updateMode="UNKNOWN"`.
 
       SDL Core removes the item `UNKNOWN` from the request.
-      The value of `updateMode` parameter becomes empty.
-      SDL Core omits empty parameter from the request.
-      Since parameter is mandatory (according to Mobile API), the request fails with the following response to mobile application:
+      The value of the `updateMode` parameter becomes empty.
+      SDL Core omits an empty parameter from the request.
+      Since the parameter is mandatory, the request fails with the following response to a mobile application:
       `success=false, resultCode = "INVALID_DATA", info="Invalid enums were removed: updateMode:UNKNOWN"`
 
       1.2 Parameter is optional: `audioStreamingIndicator="UNKNOWN"`.
 
       SDL Core removes the `UNKNOWN` item from the request.
-      The value of `audioStreamingIndicator` parameter becomes empty.
+      The value of the `audioStreamingIndicator` parameter becomes empty.
       SDL Core omits the empty parameter in the request.
-      Since the parameter is optional (according to Mobile API), the request is successfully processed with the following response to mobile application:
+      Since the parameter is optional, the request is successfully processed with the following response to a mobile application:
       `success=true, resultCode = "WARNINGS", info="Invalid enums were removed: audioStreamingIndicator:UNKNOWN"`
 
-  2. Request contains a parameter for which the value is an array of enum items.
+  2. The request contains a parameter for which the value is an array of enum items.
 
       Request: `RegisterAppInterface`.
 
       2.1 Only one enum item is unknown: `appHMIType = [ "DEFAULT", "UNKNOWN"]`.
 
       SDL Core removes the `UNKNOWN` item from the request.
-      The value of `appHMIType` parameter now contains only `DEFAULT` item (which is known one).
-      Request is successfully processed with the following response to mobile application:
+      The value of the `appHMIType` parameter now contains only `DEFAULT` item (which is known one).
+      The request is successfully processed with the following response to a mobile application:
       `success=true, resultCode = "WARNINGS", info="Invalid enums were removed: appHMIType:UNKNOWN"`
 
       2.2 All enum items are unknown: `appHMIType = [ "UNKNOWN_1", "UNKNOWN_2"]`.
 
       SDL Core removes both `UNKNOWN_1` and `UNKNOWN_2` items from the request.
       The value of `appHMIType` parameter becomes empty.
-      Since `minsize` of the parameter is `1` (according to Mobile API), the request fails with the following response to mobile application:
+      Since `minsize` of the parameter is `1`, the request fails with the following response to mobile application:
       `success=false, resultCode = "INVALID_DATA", info="Invalid enums were removed: appHMIType:UNKNOWN_1, UNKNOWN_2"`
 
-  3. Request contains a parameter (with enum item value) which is a part of the structure.
+  3. The request contains a parameter (with enum item value) which is a part of the structure.
 
       Request: `SetGlobalProperties`.
 
@@ -119,7 +125,7 @@ If a parameter includes an unknown enum value, SDL Core has to cut off such valu
 
       `success=true, resultCode = "WARNINGS", info="Invalid enums were removed: menuIcon.imageType:UNKNOWN"`
 
-  4. Request contains a parameter which is an array of elements and each element has a parameter which value is an enum item.
+  4. The request contains a parameter which is an array of elements and each element has a parameter which value is an enum item.
 
       Request: `Show`.
 
@@ -145,77 +151,15 @@ If a parameter includes an unknown enum value, SDL Core has to cut off such valu
       The request is successfully processed with the remaining button `2` and the following response is  provided to mobile application:
       `success=true, resultCode = "WARNINGS", info="Invalid enums were removed: softButtons[1].type:UNKNOWN"`
 
-### Mobile libraries changes (JavaSuite and iOS)
-
-  This solution affects the mobile application in 2 ways:
-
-  1. The way the mobile application registers itself with SDL Core.
-
-  2. The way the mobile application sends requests to SDL Core.
-
-#### Changes related to mobile application connecting to SDL Core
-  To filter out unsupported items we need to know the exact protocol version, not only the major part of it but the minor part as well since certain parameters were added in between the major change. For instance, `AppHMIType` items `PROJECTION` and `REMOTE_CONTROL` were rolled in as early as 4.5. There is a possible case when we know the major version is 4 but the information about the minor part of it is unknown before `RegisterAppInterface` request is sent and responded. However, even upon receipt of the response, the minor version of the protocol may still be not confirmed since both `syncMsgVersion` and `sdlVersion` are not mandatory parameters and thus can be absent in the response.
-
-  ***Note** for SDL *PROTOCOL* version less than 4.3 in StartServiceACK response Proxy can get only *MAJOR* version.*
-
-  ***Note** for SDL *PROTOCOL* version higher than or equal to 4.4 in in StartServiceACK response Proxy can get *MAJOR*.*MINOR*.*PATCH* versions.*
-
-  ***Note** since that moment (StartServiceACK response) and until `RegisterAppInterface` successful response, Proxy should use PROTOCOL version to filter out all unknown enum values.*
-
-  So the workflow should be implemented as follows:
-  1. The mobile application (Android/IOS) creates a proxy object (proxy) to communicate with the SDL Core.
-  2. The mobile application passes to the Proxy entity the configurations.
-  3. Among other properties the configuration object has the following parameters:
-      * Minimum SDL Core version
-      * Application HMI type(s) (`AppHMIType` array)
-
-#### Changes related to sending request(s) from mobile application to SDL Core
-  After the connection is established and mobile application is registered with SDL Core, mobile application works as usual but requires the request parameters validation. An issue will occur when the mobile application calls a method and passes an enum values array as a parameter that belongs to the higher SDL version. In this case, the Mobile Proxy should filter out unsupported params before sending the request and provide warning in logs as `unsupported_values`.
-
-  The validation sequence:
-
-  1. Mobile application sends request to SDL Core through the proxy.
-  2. The proxy checks the request parameters:
-     * If there are no enum values unknown to SDL, the proxy forwards the request to SDL Core without changes.
-
-     * If some of the enum values are unknown to SDL Core the proxy should:
-          * Filter out all RPCs' unsupported enum values including nested RPCs if those are present, before making a request to make sure it is compliant with the current spec
-          * Log a warning level with «unsupported_values» (enum’s/struct’s names)
-
-  **Note**: For `RegisterAppInterface` to filter we should use version of PROTOCOL, but not the MOBILE_API according to system’s flow. **iOS** should be extended with similar mechanism in order to encapsulate filtering logic.
-
-  **For example** :
-  If the UI app requested unsupported `AppHMIType` and version which are not compatible, then the proxy must filter unsupported HMI types.
-
-   - Before filtering :
-       ```
-       "AppHMIType" : ["DEFAULT", "MEDIA", "UKNOWN"]
-       ```
-
-   - After filtering :
-       ```
-       AppHMIType" : ["DEFAULT", "MEDIA"]
-       ```
-
-  ***Note**: In case no HMI types are left after filtering, Mobile Library should throw an exception, otherwise `RegisterAppInterface` RPC will be sent with remaining HMI types.*
-
-  ***Note**: Now system flow is the following: if `RegisterAppInterface` fails with an error then Mobile library should pass the error status to the Mobile Library adding failure reason.*
-
-  ***Note**: The protocol version control logic is partly implemented in Android and not implemented in iOS. However, what is implemented has its flaws and should be updated following the logic above.*
-
-
 ## Potential downsides
-  In the case, new RPCs would added, the new structures/enums should be implemented with additional implementation of filtering mechanism for particular objects.
 
-  **Note:** For `RegisterAppInterface` we cannot keep connection if invalid param is present due to the current flow of the older SDL versions. The connection can be dropped (End Session) by SDL Core but not by mobile device (SDL library).
+There is the case when a Mobile Application has the older API version (for example 6.0) then SDL Core and the SDL Core has the newer API version (for example 7.0).
+
+In the Mobile Application, some parameter is not mandatory and in the SDL Core, the same parameter is become as mandatory. Should keep in mind that the implementation of the SDL Core is updated according to the last API version. And in the described case if the Mobile Application will not send the parameter, that could bring the SDL Core to the incorrect behavior.
+
+This proposal doesn't cover this case and changes for that should be described in a separate proposal.
 
 ## Impact on existing code
-  **Android/iOS**
-
-   * Each `RPCStruct` should be extended with the implementation of filtering mechanism
-   * Implement logging for unsupported values
-
-**SDL Core:**
 
 Extend SDL Core logic by additional functionality of unknown values filtering.
 

--- a/proposals/0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md
+++ b/proposals/0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md
@@ -62,7 +62,7 @@ If a parameter includes an unknown enum value, SDL Core has to cut off such valu
 
   **NOTE**
 
-  ```The negotiated RPC spec version is the version that should be used for determining if a parameter is mandatory or not, as mandatory=true/false can change between different RPC spec versions.```
+  The negotiated RPC spec version is the version that should be used for determining if a parameter is mandatory or not, as mandatory=true/false can change between different RPC spec versions.
 
   In the case when mobile application has the 7.0 Mobile API/RPC spec version and the SDL Core has the 6.0 Mobile API/RPC spec version, the negotiated version will be 6.0 (the version of the SDL Core).
 

--- a/proposals/0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md
+++ b/proposals/0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md
@@ -1,5 +1,5 @@
   # Processing of unknown enum values by SDL Core
-  * Proposal: [SDL-0298](0298-Processing-of-unknown-enum-values-by-SDLCore.md)
+  * Proposal: [SDL-0298](0298-Processing-of-unknown-enum-values-by-SDL-and-Mobile-libraries.md)
   * Authors: [Igor Gapchuk](https://github.com/IGapchuk), [Dmitriy Boltovskiy](https://github.com/dboltovskyi/)
   * Status: **Returned for Revisions**
   * Impacted Platforms: [Core]
@@ -9,12 +9,12 @@ The main purpose of this proposal is to gracefully handle unknown enum values fr
 
 ## Motivation
 
-The current filtering and data validation mechanism used by SDL Core needs be improved upon to issues related to possible differences in API versions between parameters in the request from a mobile application and an SDL Core.
+The current filtering and data validation mechanism used by SDL Core needs be improved upon to issues related to possible differences in Mobile API/RPC spec versions between parameters in the request from a mobile application and an instance of SDL Core.
 
 To better understand what kinds of issues we could face, let's assume the next example:
 
-A mobile device with a newer version of the API (5.0) during connecting to the SDL Core, which has an older API version (4.3), sends a `RegisterAppInterface` request to SDL Core with an array of `AppHMITypes` which has the next values: `[DEFAULT, REMOTE_CONTROL]` (The `AppHMIType::DEFAULT` was introduced in the API since 2.0 version, since the time the `AppHMIType` type was added into the API, and `AppHMIType::REMOTE_CONTROL` was introduced in the 4.5 version of the API). SDL Core tries to validate the parameters in the RAI request, finds an unknown enum value of `AppHMIType::REMOTE_CONTROL`. As a result, the SDL Core sends a failure response to a mobile application with the `INVALID_DATA` result code. Thus, the mobile application fails to register with SDL Core that is an unacceptable user experience. Besides, the mobile application cannot conclusively determine the cause of failure since `INVALID_DATA` can be returned for a line of reasons.
-With the changes provided by this proposal, SDL Core will be able to process all unknown enums in mobile requests in the correct way and respond to mobile applications with informative messages about happed failures.
+A mobile application with a newer version of the Mobile API (5.0) while connecting to SDL Core, which has an older Mobile API version (4.3), sends a `RegisterAppInterface` request to SDL Core with an array of `AppHMITypes` which has the next values: `[DEFAULT, REMOTE_CONTROL]` (The `AppHMIType::DEFAULT` was introduced in the Mobile API since 2.0 version, since the time the `AppHMIType` type was added into the API, and `AppHMIType::REMOTE_CONTROL` was introduced in the 4.5 version of the Mobile API). SDL Core tries to validate the parameters in the RAI request, finds an unknown enum value of `AppHMIType::REMOTE_CONTROL`. As a result, the SDL Core sends a failure response to a mobile application with the `INVALID_DATA` result code. Thus, the mobile application fails to register with SDL Core, which is an unacceptable user experience. Additionally, the mobile application cannot conclusively determine the cause of failure since `INVALID_DATA` can be returned for a number of reasons.
+With the changes provided by this proposal, SDL Core will be able to process all unknown enums in mobile requests in the correct way and respond to mobile applications with informative messages about experienced failures.
 
 ## Proposed solution
 
@@ -62,13 +62,11 @@ If a parameter includes an unknown enum value, SDL Core has to cut off such valu
 
   **NOTE**
 
-  To determine the API version for choosing if a parameter is mandatory should be used the negotiated API version.
+  ```The negotiated RPC spec version is the version that should be used for determining if a parameter is mandatory or not, as mandatory=true/false can change between different RPC spec versions.```
 
-  In the case when Mobile Application has the 7.0 API version and the SDL Core has the 6.0 API version, the negotiated API version will be 6.0 (the version of the SDL Core).
+  In the case when mobile application has the 7.0 Mobile API/RPC spec version and the SDL Core has the 6.0 Mobile API/RPC spec version, the negotiated version will be 6.0 (the version of the SDL Core).
 
-  In the case when Mobile Application has the 6.0 API version and the SDL Core has the 7.0 API version, the negotiated API version will be 6.0 (the version of the Mobile Application).
-
-  Negotiated API version is the version that should be used for determining if a parameter is mandatory or not, as mandatory=true/false can change between different APIs versions
+  In the case when mobile application has the 6.0 Mobile API/RPC spec version and the SDL Core has the 7.0 Mobile API/RPC spec version, the negotiated version will be 6.0 (the version of the mobile application).
 
   1. The request contains a parameter which value is an enum item.
 
@@ -153,9 +151,9 @@ If a parameter includes an unknown enum value, SDL Core has to cut off such valu
 
 ## Potential downsides
 
-There is the case when a Mobile Application has the older API version (for example 6.0) then SDL Core and the SDL Core has the newer API version (for example 7.0).
+There is the case when a mobile application has an older Mobile API version (for example 6.0) than SDL Core and SDL Core has the newer Mobile API version (for example 7.0).
 
-In the Mobile Application, some parameter is not mandatory and in the SDL Core, the same parameter is become as mandatory. Should keep in mind that the implementation of the SDL Core is updated according to the last API version. And in the described case if the Mobile Application will not send the parameter, that could bring the SDL Core to the incorrect behavior.
+In the mobile application, some parameters are not mandatory and in SDL Core, the same parameter has become mandatory. One should keep in mind that the implementation of SDL Core is updated according to the last Mobile API version. And in the described case, if the mobile application will not send the parameter, that could bring SDL Core to the incorrect behavior.
 
 This proposal doesn't cover this case and changes for that should be described in a separate proposal.
 


### PR DESCRIPTION
Removed all parts of the proposal related to the SDL mobile libraries' changes ( this part will be provided by the project maintainer ).
Was reworked part regarding mandatory parameter in a message.
Made changes that REMOTE_CONTROL was added in RPC spec version 4.5, not 6.0
Changed the proposal title and file name.