### PR TITLE
Revise SDL-0273 Webengine projection mode.

### DIFF
--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -26,7 +26,7 @@ A new template called `WEB_VIEW` should be added. This template should have the 
 1. It's supported for in-vehicle WebEngine apps only.
 2. It's available only to the main window. It should not be available for widgets.
 3. It is only available to applications that successfully registered with the new App HMI type (see below section regarding new App HMI Type).
-4. The `WEB_VIEW` template must not declare support in its WindowCapabilities for any softButtonCapabilities, the TextFields with name: mainField1-4, mediaClock, mediaTrack, nor the ImageFields with name: softButtonImage, menuIcon, graphic, or secondaryGraphic.
+4. The `WEB_VIEW` template must not declare support in its WindowCapabilities for any `softButtonCapabilities`, the `TextFields` with name: `mainField1-4`, `mediaClock`, `mediaTrack`, nor the `ImageFields` with name: `softButtonImage`, `menuIcon`, `graphic`, or `secondaryGraphic`.
 
 If this template is used by WebEngine apps, the HMI of the IVI should present the WebEngine app and show the application's web page. 
 The application can control the web `document` object using JavaScript code to manipulate the document object model of the WebEngine app.
@@ -39,9 +39,9 @@ After pop-up is closed, touch events processing returns back to the WEB_VIEW are
 2. The HMI should include a button to access the app list
 3. The HMI should not show a menu button on the HMI. Instead the app should be required to behave as followed:
 
-    3.1 . If the app uses AddCommand or AddSubMenu the app is required to provide an own menu button on the WEB_VIEW and send ShowAppMenu if this menu button is selected by the user.
+    3.1 . If the app uses `AddCommand` or `AddSubMenu`, the app is required to provide an own menu button on the WEB_VIEW and send `ShowAppMenu` if this menu button is selected by the user.
 
-    3.2. If the app does not use commands or sub menus the app is required to provide a way to the user to exit the application. The app should use CloseApplication RPC for this.
+    3.2. If the app does not use commands or sub menus the app is required to provide a way to the user to exit the application. The app should use `CloseApplication` RPC for this.
 
 
 **MOBILE_API**

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -39,7 +39,7 @@ After pop-up is closed, touch events processing returns back to the WEB_VIEW are
 2. The HMI should include a button to access the app list
 3. The HMI should not show a menu button on the HMI. Instead the app should be required to behave as followed:
 
-    3.1 . If the app uses `AddCommand` or `AddSubMenu`, the app is required to provide an own menu button on the WEB_VIEW and send `ShowAppMenu` if this menu button is selected by the user.
+    3.1 . If the app uses `AddCommand` or `AddSubMenu`, the app is required to provide an own menu button on the `WEB_VIEW` and send `ShowAppMenu` if this menu button is selected by the user.
 
     3.2. If the app does not use commands or sub menus the app is required to provide a way to the user to exit the application. The app should use `CloseApplication` RPC for this.
 

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -26,34 +26,25 @@ A new template called `WEB_VIEW` should be added. This template should have the 
 1. It's supported for in-vehicle WebEngine apps only.
 2. It's available only to the main window. It should not be available for widgets.
 3. It is only available to applications that successfully registered with the new App HMI type (see below section regarding new App HMI Type).
-4. The `WEB_VIEW` template is not allowed to to support textfields, softbuttons, graphics (inside or outside of the webview). DuplicateUpdatesFromWindowID=0 is not allowed for widgets.
+4. The `WEB_VIEW` template must not declare support in its WindowCapabilities for any softButtonCapabilities, the TextFields with name: mainField1-4, mediaClock, mediaTrack, nor the ImageFields with name: softButtonImage, menuIcon, graphic, or secondaryGraphic.
 
 If this template is used by WebEngine apps, the HMI of the IVI should present the WebEngine app and show the application's web page. 
 The application can control the web `document` object using JavaScript code to manipulate the document object model of the WebEngine app.
 JavaScript is the only language supported within current proposal.
 The HMI should respect the WebEngine app as the first responder to touch events. This means that touchable elements in the `document` should be accessible through the system's touch screen to the user.
-If the app sends RPCs which trigger a pop-up on the HMI screen, so this pop-up overlays what WEB_VIEW area shows (Alert, PerformInteraction etc.), touch events will first go through the pop-up area.
+If the app sends RPCs which trigger a pop-up on the HMI screen, so this pop-up overlays what WEB_VIEW area shows (`Alert`, `PerformInteraction` etc.), touch events will first go through the pop-up area.
 After pop-up is closed, touch events processing returns back to the WEB_VIEW area.
 
-The HMI should include a button to access the app list, the add command menu button (or a requirement for the app to implement ShowAppMenu or otherwise implement CloseApplication), and app/template title.
-The template/app title should be visible when the app is activated. The exact location of the template/app title relies on the OEM.
+1. The HMI should include an app title and a template title. The template/app title should be visible when the app is activated. The exact location of the template/app title relies on the OEM.
+2. The HMI should include a button to access the app list
+3. The HMI should not show a menu button on the HMI. Instead the app should be required to behave as followed:
+
+    3.1 . If the app uses AddCommand or AddSubMenu the app is required to provide an own menu button on the WEB_VIEW and send ShowAppMenu if this menu button is selected by the user.
+
+    3.2. If the app does not use commands or sub menus the app is required to provide a way to the user to exit the application. The app should use CloseApplication RPC for this.
 
 
-#### 1.1. Application deactivation
-The HMI should always support showing a menu button, but it would only be shown if the app sends at least one AddCommand or AddSubMenu. If the app does not send any AddCommands or AddSubmenus, then the menu button should not be shown, but in that case the app must implement the CloseApplication RPC in an **EXIT** button somewhere in their in-app UI.
-
-![Screenshot example of a web app](../assets/proposals/0273-webengine-projection-mode/web-app-example_with_exit_button_and_template_title.jpg)
-
-> Example of a local web app presenting the user interface with the WebView.
-> App did not send any AddCommands or AddSubmenus so the EXIT button is the only
-> UI way to deactivate the app to NONE HMI Level
-
-
-If the app has sent any AddCommands or AddSubmenus, then the **MENU** button should appear.
-
-![Screenshot example of a web app](../assets/proposals/0273-webengine-projection-mode/web-app-example_with_outside_menu_and_template_title.jpg)
-
-> Example of a local web app presenting the user interface with the MENU button.
+**MOBILE_API**
 
 ```xml
 <enum name="PredefinedLayout" platform="documentation" since="3.0">
@@ -67,11 +58,19 @@ If the app has sent any AddCommands or AddSubmenus, then the **MENU** button sho
 </enum>
 ```
 
-
-
-
+![Screenshot example of a web app](../assets/proposals/0273-webengine-projection-mode/web-app-example_with_exit_button_and_template_title.jpg)
 
 > Example of a local web app presenting the user interface with the WebView.
+> App did not send any AddCommands or AddSubmenus so the EXIT button is the only
+> UI way to deactivate the app to NONE HMI Level (using `CloseApplication` RPC)
+
+
+If the app uses `AddCommand` or/and `AddSubmenu` RPCs, then the **MENU** button should be provided.
+Selecting of this button by the user should trigger the app to send `ShowAppMenu` request.
+
+![Screenshot example of a web app](../assets/proposals/0273-webengine-projection-mode/web-app-example_with_outside_menu_and_template_title.jpg)
+
+
 
 #### 1.2. Window Capabilities
 
@@ -82,19 +81,15 @@ Generally, the window capabilities should refer to available text and image fiel
 
 If the `WEB_VIEW` template is currently active, the window capabilities change as the application is presenting content using the web document.
 
-The following text fields `mainField1`, `mainField2`, `mainField3`, `mainField4`, `statusBar`, `mediaClock` and `mediaTrack` should be used practically on all the base templates. 
-It is required that `WindowCapability.textFields` should not contain these text field names if the OEM has implemented the `WEB_VIEW` template without these text fields.
-The text fields `menuName` and `templateTitle` should be included in the capabilities if these fields are visible on the HMI.
-
 The parameters `availableTemplates`, `buttonCapabilities`, and `imageTypeSupported` are independent of the currently active template and should reflect the general capabilities of the window/system.
 
 
 #### 1.3. What about widgets?
 
-Widgets are not affected by this proposal. They are still available and can be controlled using `Show` RPC. Any overlay like Alert, ChoiceSets, Slider etc. are also available to the application.
+Widgets are not affected by this proposal. They are still available and can be controlled using `Show` RPC. Any overlay like `Alert`, `ChoiceSets`, `Slider` etc. are also available to the application.
 
 Widgets that duplicate content from the main window should still be possible. Despite the window capability, the app should still be able to send `Show` requests with all the desired content. This content should be duplicated to these widgets.
-The behavior of the WEB_VIEW template with widgets that duplicate main window should align with the behavior of existing templates (ie switching from NON_MEDIA to a TILES_ONLY template with a duplicate widget).
+The behavior of the `WEB_VIEW` template with widgets that duplicate main window should align with the behavior of existing templates (ie switching from `NON_MEDIA` to a `TILES_ONLY` template with a duplicate widget).
 
 ### 2. App HMI Type `WEB_VIEW`
 
@@ -116,7 +111,7 @@ As a result, when in-vehicle apps with this HMI type are activated, the HMI shou
 ```xml
 <enum name="AppHMIType" since="2.0">
     :
-    <element name="WEB_VIEW" since="6.3" />
+    <element name="WEB_VIEW" since="6.X" />
 </enum>
 ```
 
@@ -131,27 +126,11 @@ It is required for applications to register with this App HMI type in order to u
 
 Independent of the app presentation type, the HMI will continue to provide system context information from the app. An application which uses the projection mode should continue to receive `OnHMIStatus` notifications and SDL Core will still be notified about event changes.
 
-### 3. User interface guidelines (Driver Distraction rules)
+### 3. User interface guidelines
 
 With the current depth of this proposal, the HMI type should be used by 1st party OEM apps only. With future proposals and workshops the SDLC could open the HMI type to 3rd party by creating and defining proper driver distraction and user interface guidelines.
 
 The acceptance of this proposal means the feature is available for OEM/1st party apps and content ONLY. There is an inherent risk that OEMs could use the feature to bring in 3rd party apps and content without additional proposals as it will be impossible to enforce. If an OEM takes such an action, the SDLC will be forced to bring the issue up to the Board of Directors for possible consequences.
-
-At the time of this proposal being in review, a set of driver distraction rules are being created and proposed to enable 3rd party using the projection mode. The following bullet points are items that will be described further in the ruleset:
-
-- minimum font size
-- minimum contrast between font and background
-- min/max brightness (for day and night mode)
-- number of buttons
-- minimum size of a button
-- no customized keyboard
-- no video playback (exceptions in standstill per countries)
-- NHTSA related guidelines
-    - Amount of text (button and text fields)
-    - number of lines of text
-    - Complexity of use cases (number of steps to fulfill a use case)
-
-More items may be included in the ruleset as they become Driver Distraction affected.
 
 ### 4. Application lifecycle (or, what happens if the app is closed?)
 
@@ -179,19 +158,18 @@ When an app is deactivated into HMI level NONE, the connection to Core can stay 
 
 ## Potential downsides
 
-The same downsides apply as for [SDL 0031 Mobile Projection](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0031-mobile-projection.md) because WebEngine applications that use the web view are responsible just as any projection or mobile navigation application.
+1. The same downsides apply as for [SDL 0031 Mobile Projection](https://github.com/smartdevicelink/sdl_evolution/blob/master/proposals/0031-mobile-projection.md) because WebEngine applications that use the web view are responsible just as any projection or mobile navigation application.
 
-The proposal states:
-
-> If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
-
+2. The proposal states:
+If a WebEngine application attempts to register with this HMI type but the local policy table doesn’t allow, Core should not allow the app to register.
 This can be seen as a downside as it could break with apps being used for the first time. This feature would require the IVI to implement policy table updates through the vehicle modem instead of using a mobile application. It also requires the HMI to use `SetAppProperties` upon app installation to add the app policy ID to the policy table in order to trigger the policy table update through the mode.
 
 ## Impact on existing code
 
-As a new enum element is added to the `AppHMIType` enum, other platforms are impacted by this very minor change.
+Additional enum elements have been added to the MOBILE and HMI APIs.
+This means there will be a minor version change to all app library platforms, and Core.
 Core would need to specially treat apps with this HMI type as they are not allowed to register unless permission was granted.
-Possibly SDL Server and SHAID are affected as HMI types are part of the policy system.
+SDL Server and SHAID are affected as HMI types are part of the policy system.
 
 ## Alternatives considered
 


### PR DESCRIPTION
This proposal is created based on the discussion in #767.
The revision is created based on the discussion in #912 
It extends SDL-0240 - WebEngine support for SDL JavaScript to allow using the WebEngine app's web view for the HMI in addition to the other available SDL templates.