### PR TITLE
Revise SDL-0242 Subtle Alert Style

### DIFF
--- a/proposals/0242-alert-style-subtle.md
+++ b/proposals/0242-alert-style-subtle.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0242](0242-alert-style-subtle.md)
 * Author: [Joel Fischer](https://github.com/joeljfischer)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC]
+* Impacted Platforms: [Core / iOS / Java Suite / HMI / Policy Server / RPC]
 
 ## Introduction
 This feature adds the `SubtleAlert` RPC, which presents a style of alert: the "subtle" alert. This is a "notification style" alert that does not take over the entire screen.
@@ -116,6 +116,12 @@ The proposed solution is to create a new RPC `SubtleAlert` that can be sent by d
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="2">
         <description>Array of lines of alert text fields. See TextFieldStruct. Uses subtleAlertText1, subtleAlertText2.</description>
     </param>
+    <param name="alertIcon" type="Common.Image" mandatory="false" >
+        <description>
+            Image to be displayed for the corresponding alert. See Image. 
+            If omitted, no (or the default if applicable) icon should be displayed.
+        </description>
+    </param>
     <param name="duration" type="Integer" mandatory="true" minvalue="3000" maxvalue="10000">
         <description>Timeout in milliseconds.</description>
     </param>
@@ -127,6 +133,11 @@ The proposed solution is to create a new RPC `SubtleAlert` that can be sent by d
     </param>
     <param name="appID" type="Integer" mandatory="true">
         <description>ID of application requested this RPC.</description>
+    </param>
+    <param name="cancelID" type="Integer" mandatory="false">
+        <description>
+            An ID for this specific alert to allow cancellation through the `CancelInteraction` RPC.
+        </description>
     </param>
 </function>
 
@@ -140,11 +151,31 @@ The proposed solution is to create a new RPC `SubtleAlert` that can be sent by d
     <description>
         Sent when the alert itself is touched (outside of a soft button). Touching (or otherwise selecting) the alert should open the app before sending this notification.
     </description>
+    <param name="appID" type="Integer" mandatory="true">
+        <description>ID of application that is related to this RPC.</description>
+    </param>
 </function>
 ```
 
 * Changes may need to be made to the above functions for `CancelInteraction` changes.
 * Identical changes will also need to be made to `HMI_API` `TextFieldName` and `ImageFieldName` enums as in the `MOBILE_API` changes above.
+
+### Policy Table Changes
+
+Currently the `module_config` section of the policy table has fields to limit the rate at which `Alert` requests can be sent in the `BACKGROUND` hmi level (described as "notifications"). The same mechanism should be made available for `SubtleAlert` requests:
+```
+    "subtle_notifications_per_minute_by_priority": {
+        "EMERGENCY": 60,
+        "NAVIGATION": 20,
+        "PROJECTION": 20,
+        "VOICECOM": 30,
+        "COMMUNICATION": 15,
+        "NORMAL": 10,
+        "NONE": 0
+    }
+```
+
+This will allow OEMs to manage rate-limiting for subtle alerts separate from regular alerts.
 
 ### Example Mockup
 ![Subtle Alert Mockup](../assets/proposals/0242-alert-style-subtle/subtle-alert-mockup.png)
@@ -154,6 +185,7 @@ The proposed solution is to create a new RPC `SubtleAlert` that can be sent by d
 * Touching outside of the subtle alert should close the alert.
 * Touching (or otherwise selecting) the alert should open the app before sending the `OnSubtleAlertPressed` notification.
 * The `softButtonImage` `ImageField` also affect the `SubtleAlert` soft buttons.
+* Only one `SubtleAlert` can be active per app at a time. Apps can replace their active `SubtleAlert` by sending `CancelInteraction` followed by another `SubtleAlert`.
 
 ## Potential downsides
 Because this is a new RPC and not an addition to `Alert`, this increases the API surface of the `MOBILE_API` and `HMI_API`.

--- a/proposals/0242-alert-style-subtle.md
+++ b/proposals/0242-alert-style-subtle.md
@@ -116,14 +116,14 @@ The proposed solution is to create a new RPC `SubtleAlert` that can be sent by d
     <param name="alertStrings" type="Common.TextFieldStruct" mandatory="true" array="true" minsize="0" maxsize="2">
         <description>Array of lines of alert text fields. See TextFieldStruct. Uses subtleAlertText1, subtleAlertText2.</description>
     </param>
-    <param name="alertIcon" type="Common.Image" mandatory="false" >
+    <param name="alertIcon" type="Common.Image" mandatory="false">
         <description>
             Image to be displayed for the corresponding alert. See Image. 
             If omitted, no (or the default if applicable) icon should be displayed.
         </description>
     </param>
-    <param name="duration" type="Integer" mandatory="true" minvalue="3000" maxvalue="10000">
-        <description>Timeout in milliseconds.</description>
+    <param name="duration" type="Integer" mandatory="false" minvalue="3000" maxvalue="10000">
+        <description>Timeout in milliseconds. Omitted if SoftButtons are included.</description>
     </param>
     <param name="softButtons" type="Common.SoftButton" mandatory="false" minsize="0" maxsize="2" array="true">
         <description>App defined SoftButtons</description>


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to update several RPC definitions in the proposal to account for issues during implementation as well as add a policy field to control rate limiting for `SubtleAlert` requests as is currently available for `Alert` requests.

# Motivation

To clarify details in the original proposal that became apparent during implementation.

# Proposed Solution

## HMI API Changes
1. Make the following additions to `UI.SubtleAlert` which were included in the Mobile implementation of the message:

```xml
<function name="UI.SubtleAlert" messagetype="request">
    <description>Request from SDL to show an alert message on the display.</description>
    ...
    <param name="alertIcon" type="Common.Image" mandatory="false" >
        <description>
            Image to be displayed for the corresponding alert. See Image. 
            If omitted, no (or the default if applicable) icon should be displayed.
        </description>
    </param>
    ...
    <param name="cancelID" type="Integer" mandatory="false">
        <description>
            An ID for this specific alert to allow cancellation through the `CancelInteraction` RPC.
        </description>
    </param>
...
</function>
```

2. Add an `appID` parameter to the HMI RPC `UI.OnSubtleAlertPressed`, to specify which app Core should receive this notification:

```xml
<function name="UI.OnSubtleAlertPressed" messagetype="notification">
    <description>
        Sent when the alert itself is touched (outside of a soft button). Touching (or otherwise selecting) the alert should open the app before sending this notification.
    </description>
    <param name="appID" type="Integer" mandatory="true">
        <description>ID of application that is related to this RPC.</description>
    </param>
</function>
```

This implementation still has the limitation that two `SubtleAlert` requests from the same app cannot be active at the same time, a note to this effect was added to the proposal.

3. Make `duration` non-mandatory since it is unused when softbuttons are included.

```
    <param name="duration" type="Integer" mandatory="false" minvalue="3000" maxvalue="10000">
        <description>Timeout in milliseconds. Omitted if SoftButtons are included.</description>
    </param>
```

As a note, it appears that `UI.Alert` uses the original definition for `duration` (with `mandatory="true"`) and Core sends `0` in the case that softbuttons are included, meaning that it does not follow the spec properly. Resolving this would require a separate proposal.

## Policy Table Changes

Add a section to the `module_config` in the policy table to handle rate limiting for `SubtleAlert` requests made in the background (matching the existing mechanism used for `Alert` requests):

```json
{
    "policy_table": {
        ...
        "module_config": {
            ...
             "subtle_notifications_per_minute_by_priority": {
                "EMERGENCY": 60,
                "NAVIGATION": 20,
                "PROJECTION": 20,
                "VOICECOM": 30,
                "COMMUNICATION": 15,
                "NORMAL": 10,
                "NONE": 0
            }
        }
    }
}
```

# Potential Downsides

The policy table changes in this revision will increase the complexity and scope of this feature, and the SDL Policy Server will need to accommodate this addition.

# Impact On Existing Code

Core and HMI Implementations would need to account for HMI API changes

Core and the Policy Server would need to account for the added `subtle_notifications_per_minute_by_priority` table.

# Alternatives Considered
- Instead of adding a new field to `module_config`, we could instead just apply the existing `notifications_per_minute_by_priority` to `SubtleAlert` requests. This would be a bit less flexible for OEMs, but it would also reduce the complexity of the feature in relation to the proposed solution. It is also possible to create a proposal for this addition at a later time, rather than including this in a revision to the proposal.
