### PR TITLE
Revise 0268 Main Menu Updating

### DIFF
--- a/proposals/0268-main-menu-updating.md
+++ b/proposals/0268-main-menu-updating.md
@@ -92,6 +92,10 @@ The HMI will have to support this feature and tell Core when to request menu upd
 <function name="UI.OnUpdateFile" messagetype="request">
     <description>For the HMI to tell Core that a file needs to be retrieved from the app.</description>
 
+    <param name="appID" type="Integer" mandatory="true">
+       <description>ID of application related to this RPC.</description>
+     </param>
+
     <param name="fileName" type="String" maxlength="255" mandatory="true">
         <description>File reference name.</description>
     </param>
@@ -99,6 +103,10 @@ The HMI will have to support this feature and tell Core when to request menu upd
 
 <function name="UI.OnUpdateSubMenu" messagetype="request">
     <description>For the HMI to tell Core that a submenu needs updating</description>
+
+    <param name="appID" type="Integer" mandatory="true">
+       <description>ID of application related to this RPC.</description>
+    </param>
 
     <param name="menuID" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
         <description>This menuID must match a menuID in the current menu structure</description>


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to update the new RPCs in the HMI API to include the appID of the app Core should request the neccesary menu updates from.

# Motivation

Add extra parameters to HMI API to simplify the Core logic needed for handling the HMI notifications `OnUpdateFile` and `OnUpdateSubMenu`.

# Proposed Solution

## HMI API Changes
Make the following additions to `OnUpdateFile` and `OnUpdateSubMenu`

```xml
<function name="UI.OnUpdateFile" messagetype="request">
    <description>For the HMI to tell Core that a file needs to be retrieved from the app.</description>

+    <param name="appID" type="Integer" mandatory="true">
+       <description>ID of application related to this RPC.</description>
+     </param>

    <param name="fileName" type="String" maxlength="255" mandatory="true">
        <description>File reference name.</description>
    </param>
</function>

<function name="UI.OnUpdateSubMenu" messagetype="request">
    <description>For the HMI to tell Core that a submenu needs updating</description>

+    <param name="appID" type="Integer" mandatory="true">
+       <description>ID of application related to this RPC.</description>
+    </param>

    <param name="menuID" type="Integer" minvalue="0" maxvalue="2000000000" mandatory="true">
        <description>This menuID must match a menuID in the current menu structure</description>
    </param>

    <param name="updateSubCells" type="Bool" mandatory="false">
        <description>If not set, assume false. If true, the app should send AddCommands with parentIDs matching the menuID. These AddCommands will then be attached to the submenu and displayed if the submenu is selected.</description>
    </param>
</function>
```


# Potential Downsides

Minimal impact to the HMI implementation as it requires the appID parameter to be sent with these notifications.

# Impact On Existing Code

Core and HMI Implementations need to be updated to handle the new appID parameter for the two notifications.

# Alternatives Considered
Keep the original implementation of the proposal, but add the requirement that notifications received from the HMI are for the app that is currently active or in HMI level FULL.
