### PR TITLE
Revise 0152-driver-distraction-list-limits

### DIFF
--- a/proposals/0152-driver-distraction-list-limits.md
+++ b/proposals/0152-driver-distraction-list-limits.md
@@ -52,6 +52,15 @@ We would add a new `SystemCapabilityType` and additions to `SystemCapability` to
 </struct>
 ```
 
+```xml
+<struct name="HMICapabilities" since="3.0">
+...
++    <param name="driverDistraction" type="Boolean" mandatory="false" since="7.0">
++        <description>Availability of driver distraction capability. True: Available, False: Not Available</description>
++    </param>
+</struct>
+```
+
 ## Potential downsides
 
 This would require some work on Core and / or HMI to provide configuration options and interface work for list length and menu depth when the driver is distracted. Alternately, this could be purely an HMI-level decision and configuration.


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to include the driver distraction capability as part of the HMICapabilities Struct in the RPC Spec.

# Motivation

This change is to ensure alignment with the other capability information that Core provides to the app libraries. The HMICapabilities struct supplies the app libraries with what system capability types are available.

# Proposed Solution

### Mobile API Changes
Make the following additions to the existing Struct `HMICapabilities`

```xml
<struct name="HMICapabilities" since="3.0">
...
+    <param name="driverDistraction" type="Boolean" mandatory="false" since="7.0">
+        <description>Availability of driver distraction capability. True: Available, False: Not Available</description>
+    </param>
</struct>
```


# Potential Downsides

Minimal impact as this change aligns with the existing capabilities Core provides to the app libraries. 

# Impact On Existing Code

Core and mobile libraries will need to accommodate the driverDistraction parameter in the `HMICapabilities` struct used by the `RegisterAppInterface` response.

# Alternatives Considered
No alternatives considered. 
