### PR TITLE
Revise SDL-0296 - Possibility to update video streaming capabilities during ignition cycle

### DIFF
--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -147,11 +147,13 @@ In `SDLStreamingMediaConfiguration`:
 
 **Android**
 
-In `VideoStreamManager` add new `startRemoteDisplayStream`:
+In `VideoStreamManager` add new public methods:
 
 ```java
 public void startRemoteDisplayStream(Context context, Class<? extends SdlRemoteDisplay> remoteDisplayClass,
     VideoStreamingParameters parameters, final boolean encrypted, VideoStreamingRange streamingRange)
+public Boolean isImageResolutionInRange(VideoStreamingRange range, ImageResolution currentResolution)
+public Boolean isAspectRatioInRange(VideoStreamingRange range, ImageResolution currentResolution)
 ```
 
 In this way, developers will be able to pass constraints related to specific application directly into `SDLManager`
@@ -180,10 +182,6 @@ private List<VideoStreamingCapability> getSupportedCapabilities(
 )
 ```
 
-### JavaScript APIs
-
-The JavaScript APIs will be set up in a similar way to the Obj-C / Java APIs above. All changes will be at the discretion of the Project Maintainer. However larger changes that would impact the Objective-C code above (such as adding or removing a method) will require proposal revisions.
-
 #### Resolution Switching
 
 Mobile applications should be able to update the streaming content window to the new VSCs received in `OnSystemCapabilityUpdated`.
@@ -191,6 +189,10 @@ Mobile applications should be able to update the streaming content window to the
 In order to do this, application developers would be notified with a callback `onViewResized(width, height)/videoStreamingSizeDidUpdate:(CGSize)displaySize`. It would be called once new data on resolution is retrieved from the HMI and the internal process in the app library of proper component change is finished. This callback is passed to implemented by developers classes responsible for markup, where UI reorganization could be handled.
 
 SDL Manager wouldn't check and validate the VSC that the HMI sends to the app to switch to.
+
+### JavaScript APIs
+
+The JavaScript APIs will be set up in a similar way to the Obj-C / Java APIs above. All changes will be at the discretion of the Project Maintainer. However larger changes that would impact the Objective-C code above (such as adding or removing a method) will require proposal revisions.
 
 ### HMI Integration Guidelines
 

--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0296](0296-Update-video-streaming-capabilities-during-ignition-cycle.md)
 * Author: [Dmytro Boltovskyi](https://github.com/dboltovskyi)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Java Suite / HMI]
+* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC Spec / SDL JavaScript]
 
 ## Introduction
 

--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0296](0296-Update-video-streaming-capabilities-during-ignition-cycle.md)
 * Author: [Dmytro Boltovskyi](https://github.com/dboltovskyi)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC / JavaScript Suite]
+* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC]
 
 ## Introduction
 

--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -159,10 +159,11 @@ where `VideoStreamingRange`:
 
 ```java
 public class VideoStreamingRange {
-    private Resolution minSupportedResolution;
-    private Resolution maxSupportedResolution;
-    private Double maxScreenDiagonal;
-    private AspectRatio aspectRatio;
+    private Resolution minResolution;
+    private Resolution maxResolution;
+    private Double minAspectRatio;
+    private Double maxAspectRatio;
+    private Double minScreenDiagonal;
 }
 ```
 In `SdlRemoteDisplay` implementation by mobile application developers:
@@ -173,8 +174,9 @@ Later, when alternative supported resolutions are retrieved from `HMI`, `VideoSt
 private List<VideoStreamingCapability> getSupportedCapabilities(
     Resolution minResolution,
     Resolution maxResolution,
-    Double constraintDiagonalMax,
-    AspectRatio ratioRange
+    Double minAspectRatio,
+    Double maxAspectRatio,
+    Double minScreenDiagonal
 )
 ```
 

--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0296](0296-Update-video-streaming-capabilities-during-ignition-cycle.md)
 * Author: [Dmytro Boltovskyi](https://github.com/dboltovskyi)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC Spec / SDL JavaScript]
+* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC / JavaScript Suite]
 
 ## Introduction
 

--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -3,7 +3,7 @@
 * Proposal: [SDL-0296](0296-Update-video-streaming-capabilities-during-ignition-cycle.md)
 * Author: [Dmytro Boltovskyi](https://github.com/dboltovskyi)
 * Status: **Accepted with Revisions**
-* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC]
+* Impacted Platforms: [Core / iOS / Java Suite / HMI / RPC / JavaScript Suite]
 
 ## Introduction
 
@@ -179,6 +179,10 @@ private List<VideoStreamingCapability> getSupportedCapabilities(
     Double minScreenDiagonal
 )
 ```
+
+### JavaScript APIs
+
+The JavaScript APIs will be set up in a similar way to the Obj-C / Java APIs above. All changes will be at the discretion of the Project Maintainer. However larger changes that would impact the Objective-C code above (such as adding or removing a method) will require proposal revisions.
 
 #### Resolution Switching
 


### PR DESCRIPTION
## Introduction
Update for SDL-0296 - Possibility to update video streaming capabilities during ignition cycle.
There is a discrepancy in Public API between Android and iOS mobile libraries.

## Motivation
The idea is to have the same set of properties available for app developers for all platforms.

## Proposed solution
1) Update Public API properties for Android platform in order to have them aligned with iOS:
- minResolution
- maxResolution
- minAspectRatio
- maxAspectRatio
- minScreenDiagonal

2) Extend list of impacted projects, since mobile API is going to be changed:
 - RPC Spec 
 - JavaScript Suite

## Potential downsides
The author was unable to identify any potential downsides.

## Impact on existing code
The app libraries will need to be updated

## Alternatives considered
The author was unable to identify any alternatives