### PR TITLE
SDL-0188 Interior Vehicle Data resumption revision

### DIFF
--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -34,7 +34,7 @@ Hash ID Resumption information should be added to the Best Practices guide.
 #### Restoring Interior vehicle data
 
 Restoring interior vehicle data means that SDL should :
- - Send `GetInteriorData(IsSubscribe=true)` to HMI and store data received from HMI in cache.
+ - Send `GetInteriorVehicleData (subscribe=true)` to HMI and store data received from HMI in cache.
  - Restore subscription for the app internally (OnInteriorVehicleData notification from HMI should be transmitted to mobile)
 
 SDL should behave the same as before disconnect.

--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -46,9 +46,9 @@ Reverting subscriptions means internally removing information about this subscri
 In the case that after reverting the subscription, there is no application subscribed to a certain module type, SDL should send `GetInteriorData(IsSubscribe=false)` to HMI and clear cache for this module type.
 Interior vehicle data resumption error handling should follow the same rules as regular vehicle data resumption error handling. 
 
-## SetInteriorVehicleData behavior changes:
+## GetInteriorVehicleData behavior changes:
 
-If a mobile application sends `SetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
+If a mobile application sends `GetInteriorVehicleData (subscribe=true, moduleType=MODULE1)`, but the application is already subscribed on `MODULE1` module type the resultCode should be `WARNING` because of double subscription and info should contain information if an app is already subscribed.
 
 ## Potential downsides
 

--- a/proposals/0188-get-interior-data-resumption.md
+++ b/proposals/0188-get-interior-data-resumption.md
@@ -43,7 +43,7 @@ SDL should behave the same as before disconnect.
 
 If during resumption HMI responds with error to GetInteriorVehicleDataRequest SDL should revert already subscribed data and fail resumption. 
 Reverting subscriptions means internally removing information about this subscription.
-In the case that after reverting the subscription, there is no application subscribed to a certain module type, SDL should send `GetInteriorData(IsSubscribe=false)` to HMI and clear cache for this module type.
+In the case that after reverting the subscription, there is no application subscribed to a certain module type, SDL should send `GetInteriorVehicleData (subscribe=false)` to HMI and clear cache for this module type.
 Interior vehicle data resumption error handling should follow the same rules as regular vehicle data resumption error handling. 
 
 ## GetInteriorVehicleData behavior changes:


### PR DESCRIPTION
## Introduction 

Update "SDL-0188 Interior Vehicle Data resumption." The revision is in the scope of fixing typos to match the RPC Spec.

## Motivation

Fix typos to avoid confusion in further activities.

## Proposed solution 

Fix parameter names for GetInteriorVehicleData from `IsSubscribe` to `subscribe` according to the existing API.


In behaviour changes block, replace `SetInteriorVehicleData` with the `GetInteriorVehicleData` RPC that was initially meant.

## Potential downsides 
 N/A

## Impact on existing code
 N/A

## Alternatives considered
 N/A
