### PR TITLE
Revise 0273-webengine-projection-mode

### DIFF
--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -117,7 +117,25 @@ As a result, when in-vehicle apps with this HMI type are activated, the HMI shou
 
 #### 2.1. Policy control
 
-The HMI type `WEB_VIEW` should be policy controlled. On the policy server this HMI type can be added to the valid HMI type list per app ID.
+The HMI type `WEB_VIEW` should be policy controlled. On the policy server this HMI type can be added to the `AppHMIType` array in the app specific policy.
+
+Example app policy entry with `AppHMIType` parameter:
+
+```
+"webengine-appID-123": {
+    "AppHMIType": [ "WEB_VIEW" ],
+    "keep_context": false,
+    "steal_focus": false,
+    "priority": "NONE",
+    "default_hmi": "NONE",
+    "groups": ["Base-4", "WidgetSupport"],
+     "hybrid_app_preference": "CLOUD",
+     "enabled": false,
+     "transport_type ": "WS"
+}
+```
+
+Note: If the AppHMIType parameter is omitted from app policy, then that app is permitted to use all AppHMITypes. This is an existing behavior in Core and should not be changed for the enforcement of the `WEB_VIEW` `AppHMIType`.
 
 Only apps with permissions to use this HMI type would be allowed to register. If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
 It is required for applications to register with this App HMI type in order to use the `WEB_VIEW` template. Otherwise the `WEB_VIEW` template should not be available.

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -135,7 +135,7 @@ Example app policy entry with `AppHMIType` parameter:
 }
 ```
 
-Note: If the AppHMIType parameter is omitted from app policy, then that app is permitted to use all AppHMITypes. This is an existing behavior in Core and should not be changed for the enforcement of the `WEB_VIEW` `AppHMIType`.
+Note: If the AppHMIType parameter is omitted from the app's policy, then that app is permitted to use all AppHMITypes. This is an existing behavior in Core and should not be changed for the enforcement of the `WEB_VIEW` `AppHMIType`.
 
 Only apps with permissions to use this HMI type would be allowed to register. If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
 It is required for applications to register with this App HMI type in order to use the `WEB_VIEW` template. Otherwise the `WEB_VIEW` template should not be available.

--- a/proposals/0273-webengine-projection-mode.md
+++ b/proposals/0273-webengine-projection-mode.md
@@ -135,10 +135,10 @@ Example app policy entry with `AppHMIType` parameter:
 }
 ```
 
-Note: If the AppHMIType parameter is omitted from the app's policy, then that app is permitted to use all AppHMITypes. This is an existing behavior in Core and should not be changed for the enforcement of the `WEB_VIEW` `AppHMIType`.
+Note: If the `AppHMIType` parameter is omitted from the app's policy, then that app is permitted to use all `AppHMIType` values. This is an existing behavior in Core and should not be changed for the enforcement of the `WEB_VIEW` `AppHMIType`.
 
 Only apps with permissions to use this HMI type would be allowed to register. If a WebEngine application attempts to register with this HMI type but the local policy table doesn't allow, Core should not allow the app to register.
-It is required for applications to register with this App HMI type in order to use the `WEB_VIEW` template. Otherwise the `WEB_VIEW` template should not be available.
+It is required for applications to register with this `AppHMIType` in order to use the `WEB_VIEW` template. Otherwise the `WEB_VIEW` template should not be available.
 
 #### 2.2. System context and event change
 


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, and unimplemented proposal (but is currently under review). The suggested revision is to add clarifying language to the Policy Control section of the original proposal about the behavior of including vs omitting the `AppHMIType` parameter.

# Motivation

Traditionally, if the `AppHMIType` parameter was omitted from an app's policy entry, that implied that all `AppHMIType` values would be allowed without issue. The language used in the proposal does not explicitly state that the behavior of omitting `AppHMIType` should change, but it could be implied that `AppHMIType: ["WEB_VIEW"]` must be included in an app's policy in order for a registration to be allowed. I added a clarifying note to the proposal which will help preserve the original policy behavior in SDL Core.

In addition to the clarifying note, I added an example policy entry that contains the `AppHMIType` parameter in case some SDLC members were unaware of this parameter's usage.

# Proposed Solution

- Add note to the proposal stating the existing behavior of "omitting `AppHMIType`", and that this behavior should not change.

> Note: If the `AppHMIType` parameter is omitted from app policy, then that app is permitted to use all `AppHMIType` values. This is an existing behavior in Core and should not be changed for the enforcement of the `WEB_VIEW` `AppHMIType`. 

# Potential Downsides

Preserving the original `AppHMIType` behavior makes policy control slightly more permissive for `WEB_VIEW` but I believe this outweighs the downside of including a 1 off exception in the policy table.

# Impact On Existing Code

The code under review for this feature will need to be updated in SDL Core to allow all `AppHMIType` values (including `WEB_VIEW`) if the `AppHMIType` param is omitted.

SDL server should make sure `AppHMIType` is included in an app policy when it is specified.

# Alternatives Considered
Use the implementation where `AppHMIType: ["WEB_VIEW"]` must be defined in the policy table.