### PR TITLE
Revise SDL-0305 Homogenize TextFieldName

### DIFF
--- a/proposals/0305-homogenize-textfieldname.md
+++ b/proposals/0305-homogenize-textfieldname.md
@@ -52,12 +52,12 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
    </element>
 -   <element name="timeToDestination"/>
 +   <element name="timeToDestination">
-+     <description>Optional time to destination field for ShowConstantTBT</description>
++     <description>Optional time to destination field for `ShowConstantTBT`</description>
 +   </element>
 -    <!-- TO DO to be removed -->
 -   <element name="turnText"/>
 +   <element name="turnText">
-+     <description>Turn text for turnList parameter of UpdateTurnList</description>
++     <description>Turn text for `turnList` parameter of `UpdateTurnList`</description>
 +   </element>
 -  <element name="navigationText">
 -    <description>Navigation text for turnList parameter of UpdateTurnList</description>
@@ -70,7 +70,7 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
  <struct name="Turn">
    <param name="navigationText" type="Common.TextFieldStruct" mandatory="false">
 -     <description>Uses navigationText from TextFieldStruct.</description>
-+     <description>Describes the turn using TextFieldName turnText</description>
++     <description>Describes the `Turn` using `TextFieldName` `turnText`</description>
    </param>
    <param name="turnIcon" type="Common.Image" mandatory="false">
    </param>

--- a/proposals/0305-homogenize-textfieldname.md
+++ b/proposals/0305-homogenize-textfieldname.md
@@ -35,18 +35,12 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
 +       <element name="turnText" since="X.X"/>
 +           <description>Turn text for turnList parameter of UpdateTurnList</description>
 +       </element>
-+
-+       <element name="navigationText" since="X.X">
-+           <description>Navigation text for turnList parameter of UpdateTurnList</description>
-+       </element>
     </enum>
 ```
 
 `timeToDestination` is added because it exists in the [`HMI_API.xml`](https://github.com/smartdevicelink/sdl_core/blob/6.1.1/src/components/interfaces/HMI_API.xml#L627) and can be used in the [`ShowConstantTBT` RPC](https://smartdevicelink.com/en/docs/hmi/master/navigation/showconstanttbt/).
 
 `turnText` is added because it exists in the [`HMI_API.xml`](https://github.com/smartdevicelink/sdl_core/blob/6.1.1/src/components/interfaces/HMI_API.xml#L629) and can be used in the [`UpdateTurnList` RPC](https://smartdevicelink.com/en/docs/hmi/master/navigation/updateturnlist/).
-
-`navigationText` is added because it exists in the [`HMI_API.xml`](https://github.com/smartdevicelink/sdl_core/blob/6.1.1/src/components/interfaces/HMI_API.xml#L630) and can be used in the [`UpdateTurnList` RPC](https://smartdevicelink.com/en/docs/hmi/master/navigation/updateturnlist/).
 
 #### HMI_API.xml
 
@@ -65,9 +59,9 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
 +   <element name="turnText">
 +     <description>Turn text for turnList parameter of UpdateTurnList</description>
 +   </element>
-   <element name="navigationText">
-     <description>Navigation text for turnList parameter of UpdateTurnList</description>
-   </element>
+-  <element name="navigationText">
+-    <description>Navigation text for turnList parameter of UpdateTurnList</description>
+-  </element>
 -  <element name="notificationText">
 -    <description>Text of notification to be displayed on screen.</description>
 -  </element>
@@ -75,6 +69,7 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
 ```
 
 `notificationText` is removed because it does not exist in the `MOBILE_API.xml` and is not used currently.
+`navigationText` is removed because it does not exist in the `MOBILE_API.xml` and is not used currently.
 
 The comment `<!-- TO DO to be removed -->` is removed because it is no longer relevant.
 
@@ -88,10 +83,10 @@ The author doesn't know of any downsides to this proposal.
 
 The `MOBILE_API.xml` changes will have no impact on existing code as only additions are made.
 
-The `HMI_API.xml` changes will require updates to HMIs to remove `notificationText` from their capabilities and an update to Core to remove the processing of the `notificationText` `TextFieldName` capability.
+The `HMI_API.xml` changes will require updates to HMIs to remove `notificationText` and `navigationText` from their capabilities and an update to Core to remove the processing of the `notificationText` and `navigationText` `TextFieldName` capabilities.
 
 ## Alternatives considered
 
 The author considered making no changes to the spec but this would be confusing to developers and would cause problems when another element is added to the `TextFieldName` enum.
 
-The author considered not removing `notificationText` but this solution would also cause problems when another element is added to the `TextFieldName` enum.
+The author considered not removing `notificationText` or `navigationText` but this solution would also cause problems when another element is added to the `TextFieldName` enum.

--- a/proposals/0305-homogenize-textfieldname.md
+++ b/proposals/0305-homogenize-textfieldname.md
@@ -66,6 +66,15 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
 -    <description>Text of notification to be displayed on screen.</description>
 -  </element>
  </enum>
+ ...
+ <struct name="Turn">
+   <param name="navigationText" type="Common.TextFieldStruct" mandatory="false">
+-     <description>Uses navigationText from TextFieldStruct.</description>
++     <description>Describes the turn using TextFieldName turnText</description>
+   </param>
+   <param name="turnIcon" type="Common.Image" mandatory="false">
+   </param>
+ </struct>
 ```
 
 `notificationText` is removed because it does not exist in the `MOBILE_API.xml` and is not used currently.
@@ -74,6 +83,10 @@ All fields that currently exist only in the `HMI_API.xml` used to also exist in 
 The comment `<!-- TO DO to be removed -->` is removed because it is no longer relevant.
 
 Descriptions are added to both `timeToDestination` and `turnText`.
+
+#### HMI Integration Guidelines
+
+Clarify that `UpdateTurnList` is using `fieldName` `turnText` within `TextField` parameter `navigationText`.
 
 ## Potential downsides
 


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to remove the TextFieldName `navigationText` from the HMI_API.xml instead of adding it to the MOBILE_API.xml. As described `navigationText` and `turnText` refer to the same text field, and `turnText` is the only one of the two that is used in SDL Core, so `navigationText` is redundant and can be removed.

# Motivation

It has been noticed that `navigationText` is not used by sdl_core or either supported HMI as a TextFieldName.

# Proposed Solution

The proposed solution is to remove redundant TextFieldName `navigationText` from the project.

## HMI API Changes
Remove `navigationText` from `TextFieldName`

```xml
  <enum name="TextFieldName">
  ...
-  <element name="navigationText">
-    <description>Navigation text for turnList parameter of UpdateTurnList</description>
-  </element>
  </enum>
```


## Mobile API Changes
Do not add `navigationText` to `TextFieldName`

```xml
  <enum name="TextFieldName" since="1.0">
  ...
- +       <element name="navigationText" since="X.X">
- +           <description>Navigation text for turnList parameter of UpdateTurnList</description>
- +       </element>
  </enum>
```

# Potential Downsides

The author does not foresee any potential downsides as this TextFieldName is not used.

# Impact On Existing Code

Some additional changes would be required to remove `navigationText` from HMI capabilities.
