### PR TITLE
Revise SDL 0267 Main Menu UI Updates

### DIFF
--- a/proposals/0267-addcommand-ui-updates.md
+++ b/proposals/0267-addcommand-ui-updates.md
@@ -99,9 +99,10 @@ We also need to expand our capabilities so that developers and high-level manage
 ### HMI_API Updates
 Updates also need to be made to the HMI_API so that Core can communicate with the HMI about the new types.
 
-###### AddSubmenu
+###### Common.MenuParams
+
 ```xml
-<function name="UI.AddSubMenu" messagetype="request">
+<struct name="MenuParams">
     <!-- New Parameters -->
     <param name="secondaryText" maxlength="500" type="String" mandatory="false">
         <description>Optional secondary text to display</description>
@@ -109,6 +110,13 @@ Updates also need to be made to the HMI_API so that Core can communicate with th
     <param name="tertiaryText" maxlength="500" type="String" mandatory="false">
         <description>Optional tertiary text to display</description>
     </param>
+</struct>
+```
+
+###### AddSubmenu
+```xml
+<function name="UI.AddSubMenu" messagetype="request">
+    <!-- New Parameters -->
     <param name="secondaryImage" type="Image" mandatory="false">
         <description>Optional secondary image struct for menu cell</description>
     </param>
@@ -119,12 +127,6 @@ Updates also need to be made to the HMI_API so that Core can communicate with th
 ```xml
 <function name="UI.AddCommand" messagetype="request">
     <!-- New Parameters -->
-    <param name="secondaryText" maxlength="500" type="String" mandatory="false">
-        <description>Optional secondary text to display</description>
-    </param>
-    <param name="tertiaryText" maxlength="500" type="String" mandatory="false">
-        <description>Optional tertiary text to display</description>
-    </param>
     <param name="secondaryImage" type="Image" mandatory="false">
         <description>Optional secondary image struct for menu cell</description>
     </param>


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to reorganize parameters into an existing struct in the HMI_API.xml. Instead of including the text type parameters at the top level of the requests for `UI.AddCommand` and `UI.AddSubMenu`, I propose to include these parameters in `Common.MenuParams`.

# Motivation

The revising author noticed in the HMI API, all text related parameters used by `UI.AddCommand` and `UI.AddSubMenu` are included in the `Common.MenuParams` Struct.

# Proposed Solution

Move parameters `secondaryText` and `tertiaryText` from the request body to the MenuParams struct.

Update the proposed HMI API Changes to the following:

## HMI API Changes

###### Common.MenuParams

```xml
<struct name="MenuParams">
    <!-- New Parameters -->
    <param name="secondaryText" maxlength="500" type="String" mandatory="false">
        <description>Optional secondary text to display</description>
    </param>
    <param name="tertiaryText" maxlength="500" type="String" mandatory="false">
        <description>Optional tertiary text to display</description>
    </param>
</struct>
```

###### AddSubmenu
```xml
<function name="UI.AddSubMenu" messagetype="request">
    <!-- New Parameters -->
    <param name="secondaryImage" type="Image" mandatory="false">
        <description>Optional secondary image struct for menu cell</description>
    </param>
</function>
```

###### AddCommand
```xml
<function name="UI.AddCommand" messagetype="request">
    <!-- New Parameters -->
    <param name="secondaryImage" type="Image" mandatory="false">
        <description>Optional secondary image struct for menu cell</description>
    </param>
</function>
```

# Potential Downsides

The author does not foresee any potential downsides. Organizing parameters this way better fits the current menu implementation.

# Impact On Existing Code

Only changes needed to the HMI_API.xml. No changes required on the mobile side.
