### PR TITLE
Revise SDL-0296 Possibility to update video streaming capabilities during ignition cycle

### DIFF
--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -194,7 +194,7 @@ private List<VideoStreamingCapability> getSupportedCapabilities(
 #### Mobile Implementation Details
 
 1. If both `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` are not set or set to `nil/null` by the developer, then the mobile library will support all `VideoStreamingCapabilities` returned by the module. This is done to ensure that streaming works as intended for developers who don't update the library to add the `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` parameters.
-2. To disable either `supportedPortraitStreamingRange` or `supportedLandscapeStreamingRange`, the developer has to set a `VideoStreamingRange` with the `minimumResolution` and `maximumResolution` set to `0` width and `0` height. A `disabled` init was added to the iOS library to make this easier for developers. 
+2. To disable either `supportedPortraitStreamingRange` or `supportedLandscapeStreamingRange`, the developer has to set a `VideoStreamingRange` with the `minimumResolution` and `maximumResolution` set to `0` width and `0` height. A `disabled` init was added to the iOS library to make this easier for developers. If the developer chooses to disable both `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange`, video will not stream.
 3. If `supportedPortraitStreamingRange` is not set or was set to `nil/null` then the library will assume that all `VideoStreamingCapabilities` with a portrait aspect ratio are supported. The same is true if `supportedLandscapeStreamingRange` is not set; the library will assume that all `VideoStreamingCapabilities` with a landscape aspect ratio are supported.
 
 #### Resolution Switching

--- a/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
+++ b/proposals/0296-Update-video-streaming-capabilities-during-ignition-cycle.md
@@ -173,7 +173,7 @@ public class VideoStreamingRange {
     // Check if the argument is within the [.minimumResolution, .maximumResolution] range
     public Boolean isImageResolutionInRange(ImageResolution imageResolution) {}
     // Check if the argument is within the [.minimumAspectRatio, .maximumAspectRatio] range
-    public Boolean isAspectRatioInRange(Double imageResolution) {}
+    public Boolean isAspectRatioInRange(Double aspectRatio) {}
 }
 ```
 
@@ -193,9 +193,9 @@ private List<VideoStreamingCapability> getSupportedCapabilities(
 
 #### Mobile Implementation Details
 
-1. If both `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` are not set by the developer, then the mobile library will support all `VideoStreamingCapabilities` returned by the module. This is done to ensure that streaming works as intended for developers who don't update the library to add the `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` parameters.
-2. To disable either `supportedPortraitStreamingRange` or `supportedLandscapeStreamingRange`, the developer has to set a `VideoStreamingRange` with the `minimumResolution` and `maximumResolution` set to `0`. A `disabled` init was added to the iOS library to make this easier for developers. 
-3. If `supportedPortraitStreamingRange` is not set or was set to `nil` then the library will assume that all `VideoStreamingCapabilities` with a portrait aspect ratio are supported. The same is true if `supportedLandscapeStreamingRange` is not set; the library will assume that all `VideoStreamingCapabilities` with a landscape aspect ratio are supported.
+1. If both `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` are not set or set to `nil/null` by the developer, then the mobile library will support all `VideoStreamingCapabilities` returned by the module. This is done to ensure that streaming works as intended for developers who don't update the library to add the `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` parameters.
+2. To disable either `supportedPortraitStreamingRange` or `supportedLandscapeStreamingRange`, the developer has to set a `VideoStreamingRange` with the `minimumResolution` and `maximumResolution` set to `0` width and `0` height. A `disabled` init was added to the iOS library to make this easier for developers. 
+3. If `supportedPortraitStreamingRange` is not set or was set to `nil/null` then the library will assume that all `VideoStreamingCapabilities` with a portrait aspect ratio are supported. The same is true if `supportedLandscapeStreamingRange` is not set; the library will assume that all `VideoStreamingCapabilities` with a landscape aspect ratio are supported.
 
 #### Resolution Switching
 


### PR DESCRIPTION
# Introduction
This proposal is to update SDL-0296 (Possibility to update video streaming capabilities during ignition cycle) to slightly modify the Java-Suite and iOS public APIs to bring them into alignment. Implementation details were also added for the mobile libraries in order to clarify behavior when the developer has not configured a supported a video streaming range. 

# Proposed Solution

## 1. Relocate Public API for alignment  
In the Java-Suite library, move the `isImageResolutionInRange` and `isAspectRatioInRange` functions from the `VideoStreamManager` class to the `VideoStreamingRange` class in order to align the Java-Suite and iOS libraries.

```java
/// Removed API from the VideoStreamManager
public Boolean isImageResolutionInRange(VideoStreamingRange range, ImageResolution currentResolution)
public Boolean isAspectRatioInRange(VideoStreamingRange range, ImageResolution currentResolution)

/// New API on the VideoStreamingRange
public Boolean isImageResolutionInRange(ImageResolution imageResolution) {}
public Boolean isAspectRatioInRange(Double aspectRatio) {}
```

## 2. Update Property Names and Methods for Alignment
In the Java-Suite library, update the property names on `VideoStreamingRange` in order to align the Java-Suite library with the iOS library
 
```java
/// Removed API on the VideoStreamingRange
private Double minAspectRatio;
private Double maxAspectRatio;
private Double minScreenDiagonal;
private Resolution minResolution;
private Resolution maxResolution;

/// New API on the VideoStreamingRange
private Double minimumAspectRatio;
private Double maximumAspectRatio;
private Double minimumDiagonal;
private Resolution minimumResolution;
private Resolution maximumResolution;
```

In the Java-Suite library, update the `startRemoteDisplayStream` method on `VideoStreamManager` in order to allow the developer to set a `supportedLandscapeStreamingRange ` and `supportedPortraitStreamingRange` similar to the behavior of the iOS library. 

```java
/// Removed API on the VideoStreamManager
public void startRemoteDisplayStream(Context context, Class<? extends SdlRemoteDisplay> remoteDisplayClass, VideoStreamingParameters parameters, final boolean encrypted, VideoStreamingRange streamingRange)

/// New API on the VideoStreamManager
public void startRemoteDisplayStream(Context context, Class<? extends SdlRemoteDisplay> remoteDisplayClass, VideoStreamingParameters parameters, final boolean encrypted, VideoStreamingRange supportedLandscapeStreamingRange, VideoStreamingRange supportedPortraitStreamingRange)
```

## 3. Add Additional Implementation Details 
The following implementation details were added to ensure that behavior of all the mobile libraries are in alignment:
1. If both `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` are not set or set to `nil/null` by the developer, then the mobile library will support all `VideoStreamingCapabilities` returned by the module. This is done to ensure that streaming works as intended for developers who don't update the library to add the `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange` parameters.
2. To disable either `supportedPortraitStreamingRange` or `supportedLandscapeStreamingRange`, the developer has to set a `VideoStreamingRange` with the `minimumResolution` and `maximumResolution` set to `0` width and `0` height. A `disabled` init was added to the iOS library to make this easier for developers. If the developer chooses to disable both `supportedPortraitStreamingRange` and `supportedLandscapeStreamingRange`, video will not stream.
3. If `supportedPortraitStreamingRange` is not set or was set to `nil/null` then the library will assume that all `VideoStreamingCapabilities` with a portrait aspect ratio are supported. The same is true if `supportedLandscapeStreamingRange` is not set; the library will assume that all `VideoStreamingCapabilities` with a landscape aspect ratio are supported.

# Potential downsides
None.

# Impact on existing code
None.

# Alternatives considered
No alternatives considered.
