### PR TITLE
Revise SDL-0334 - Transform SetDisplayLayout requests into UI.Show for HMIs

### DIFF
--- a/proposals/0334-transform-setdisplaylayout-requests-to-ui-show.md
+++ b/proposals/0334-transform-setdisplaylayout-requests-to-ui-show.md
@@ -104,6 +104,45 @@ void SetDisplayLayoutRequest::on_event(const event_engine::Event& event) {
 }
 ```
 
+### API Changes
+
+The author also proposes removing the deprecated `SetDisplayLayout` RPC from the HMI_API spec.
+
+```xml
+...
+-  <function name="SetDisplayLayout" messagetype="request">
+-    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
+-    <param name="displayLayout" type="String" maxlength="500" mandatory="true">
+-      <description>
+-        Predefined or dynamically created screen layout.
+-        Currently only predefined screen layouts are defined.
+-      </description>
+-    </param>
+-    <param name="appID" type="Integer" mandatory="true">
+-      <description>ID of application related to this RPC.</description>
+-    </param>
+-    <param name="dayColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
+-    <param name="nightColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
+-  </function>
+-
+-  <function name="SetDisplayLayout" messagetype="response">
+-    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
+-    <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="false">
+-      <description>See DisplayCapabilities</description>
+-    </param>
+-    <param name="buttonCapabilities" type="Common.ButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
+-      <description>See ButtonCapabilities</description >
+-    </param>
+-    <param name="softButtonCapabilities" type="Common.SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
+-      <description>If returned, the platform supports on-screen SoftButtons; see SoftButtonCapabilities.</description >
+-    </param>
+-    <param name="presetBankCapabilities" type="Common.PresetBankCapabilities" mandatory="false">
+-      <description>If returned, the platform supports custom on-screen Presets; see PresetBankCapabilities.</description >
+-    </param>
+-  </function>
+...
+```
+
 ## Potential downsides
 
 These changes will prevent us from directly testing the `UI.SetDisplayLayout` RPC.

--- a/proposals/0334-transform-setdisplaylayout-requests-to-ui-show.md
+++ b/proposals/0334-transform-setdisplaylayout-requests-to-ui-show.md
@@ -104,7 +104,7 @@ void SetDisplayLayoutRequest::on_event(const event_engine::Event& event) {
 }
 ```
 
-### API Changes
+### HMI API Changes
 
 The author also proposes removing the deprecated `SetDisplayLayout` RPC from the HMI_API spec.
 
@@ -124,7 +124,7 @@ The author also proposes removing the deprecated `SetDisplayLayout` RPC from the
 -    <param name="dayColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
 -    <param name="nightColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
 -  </function>
--
+
 -  <function name="SetDisplayLayout" messagetype="response">
 -    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
 -    <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="false">


### PR DESCRIPTION
# Introduction

This is a revision to an accepted, but not yet implemented proposal. The suggested revision is to remove the deprecated `UI.SetDisplayLayout` RPC from the HMI_API.

# Motivation

The original proposal requires core to transform all incoming mobile `SetDisplayLayout` requests to `UI.Show` requests to be forwarded to the HMI. Since core will no longer send `UI.SetDisplayLayout` requests to the HMI, the RPC can be removed from HMI_API spec.

# Proposed Solution

The proposed solution is to remove the deprecated `SetDisplayLayout` RPC from the HMI_API.

```xml
...
-  <function name="SetDisplayLayout" messagetype="request">
-    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
-    <param name="displayLayout" type="String" maxlength="500" mandatory="true">
-      <description>
-        Predefined or dynamically created screen layout.
-        Currently only predefined screen layouts are defined.
-      </description>
-    </param>
-    <param name="appID" type="Integer" mandatory="true">
-      <description>ID of application related to this RPC.</description>
-    </param>
-    <param name="dayColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
-    <param name="nightColorScheme" type="Common.TemplateColorScheme" mandatory="false"></param>
-  </function>

-  <function name="SetDisplayLayout" messagetype="response">
-    <description>This RPC is deprecated. Use Show RPC to change layout.</description>
-    <param name="displayCapabilities" type="Common.DisplayCapabilities" mandatory="false">
-      <description>See DisplayCapabilities</description>
-    </param>
-    <param name="buttonCapabilities" type="Common.ButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
-      <description>See ButtonCapabilities</description >
-    </param>
-    <param name="softButtonCapabilities" type="Common.SoftButtonCapabilities" minsize="1" maxsize="100" array="true" mandatory="false">
-      <description>If returned, the platform supports on-screen SoftButtons; see SoftButtonCapabilities.</description >
-    </param>
-    <param name="presetBankCapabilities" type="Common.PresetBankCapabilities" mandatory="false">
-      <description>If returned, the platform supports custom on-screen Presets; see PresetBankCapabilities.</description >
-    </param>
-  </function>
...
```

# Potential Downsides

The author does not foresee any potential downsides.

# Impact On Existing Code

Only removes the RPC from HMI_API.xml. No changes are required on the mobile side.
