### PR TITLE
Revise SDL 0338 - Remove Unused Files From SDL Core

### DIFF
--- a/proposals/0338-remove-unused-files-from-sdl-core.md
+++ b/proposals/0338-remove-unused-files-from-sdl-core.md
@@ -17,8 +17,6 @@ In an effort to trim the code base of SDL Core the author would like to remove s
 
 Remove the following files:
 
-- [system.cc](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/utils/src/system.cc)
-- [system.h](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/utils/include/utils/system.h)
 - [thread_manager.cc](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/utils/src/threads/thread_manager.cc)
 - [thread_manager.h](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/utils/include/utils/threads/thread_manager.h)
 - [pulse_thread_delegate.cc](https://github.com/smartdevicelink/sdl_core/blob/master/src/components/utils/src/threads/pulse_thread_delegate.cc)


### PR DESCRIPTION
# Introduction

This is a revision to an accepted proposal. The revision is to keep two files that were found to be used in the project.

# Motivation

During the implementation of this proposal it was found that system.cc and system.h are still used by SDL Core and should not be removed from the project.

# Proposed Solution

Update the proposal to not include system.cc and system.h in the list of files to remove.

# Potential Downsides

The author does not see any potential downsides that weren't already addressed in the original proposal.

# Impact On Existing Code

system.cc and system.h will be kept in the SDL Core project.

# Alternatives Considered

The alternative would be to completely revert the original proposal.
